### PR TITLE
release: v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Thumbs.db
 
 # Property test regressions
 *.proptest-regressions
+
+# Local dev files
+.claude-profile
+*.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-12
+
+### Changed
+- Reimplemented ~33 applets to POSIX conformance (date, env, id, getconf, cut,
+  tr, sort, uniq, head, tail, wc, nl, paste, fold, printf, grep, sed, awk, find,
+  ls, ln, cp, dd, mkfifo, xargs, expr, test/`[`, cmp, nice, nohup, renice, sleep,
+  base64) — many previously ignored their arguments or were stubs.
+- Consolidated the grep/sed/awk/expr regex engines into one shared engine
+  (`applets::regex`), now an iterative Pike VM: linear-time matching with no
+  recursion/stack-depth caps and no catastrophic backtracking.
+
+### Fixed
+- Security & data loss: `su` now authenticates against `/etc/shadow`;
+  `cp`/`mv`/`truncate`/`gunzip` no longer destroy data on error; `kill` signal
+  handling corrected; `tar`/`unzip`/`cpio`/`httpd` path traversal closed.
+- Engine hardening: regex `{n,m}` caps, `printf` width cap; checked output
+  writes and `--help` handling across the text applets.
+
+### abp package manager (0.2.0)
+- Replaced the broken hand-rolled Ed25519 with `ed25519-dalek` (RFC 8032 KATs);
+  byte-exact signature verification; extraction escapes closed (symlink targets,
+  `O_NOFOLLOW`, setuid mask, integrity over all member types); parse-overflow
+  and OOB panics fixed; atomic install with rollback; GNU longname/pax + base-256
+  tar handling; per-file content verification; 256 MiB decompression cap.
+
+### zstd-nostd (0.2.0)
+- Added `decompress_bounded` for a caller-supplied output cap.
+
 ## [0.3.0] - 2026-01-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ed25519-dalek",
  "libc",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "armybox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "abp",
  "libc",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "zstd-nostd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ruzstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/abp", "crates/zstd-nostd"]
 
 [package]
 name = "armybox"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Pegasus Heavy Industries <contact@pegasusheavy.industries>"]
@@ -465,8 +465,8 @@ abp = ["alloc", "dep:abp"]  # Armybox Package Manager (ABP)
 [dependencies]
 # Core dependency - provides syscall interface
 libc = "0.2"
-abp = { version = "0.1.0", path = "crates/abp", optional = true, default-features = false, features = ["alloc"] }
-zstd-nostd = { version = "0.1.0", path = "crates/zstd-nostd", optional = true, default-features = false, features = ["alloc"] }
+abp = { version = "0.2.0", path = "crates/abp", optional = true, default-features = false, features = ["alloc"] }
+zstd-nostd = { version = "0.2.0", path = "crates/zstd-nostd", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 # For testing only - benchmarks are in crates/benchmarks

--- a/crates/abp/Cargo.toml
+++ b/crates/abp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Pegasus Heavy Industries <contact@pegasusheavy.industries>"]
@@ -19,7 +19,7 @@ alloc = []
 [dependencies]
 ed25519-dalek = { version = "3.0.0", default-features = false }
 libc = "0.2"
-zstd-nostd = { version = "0.1.0", path = "../zstd-nostd", features = ["alloc"] }
+zstd-nostd = { version = "0.2.0", path = "../zstd-nostd", features = ["alloc"] }
 
 [dev-dependencies]
 # Needed by tests/security.rs to produce *real* ed25519 signatures (SigningKey +

--- a/crates/zstd-nostd/Cargo.toml
+++ b/crates/zstd-nostd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zstd-nostd"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Pegasus Heavy Industries <contact@pegasusheavy.industries>"]

--- a/man/man1/armybox.1
+++ b/man/man1/armybox.1
@@ -2,7 +2,7 @@
 .\" Copyright (c) 2026 Pegasus Heavy Industries LLC
 .\" Licensed under MIT OR Apache-2.0
 .\"
-.TH ARMYBOX 1 "2026-02-08" "armybox 0.3.0" "ArmyBox Manual"
+.TH ARMYBOX 1 "2026-02-08" "armybox 0.4.0" "ArmyBox Manual"
 .\"
 .SH NAME
 armybox \- a memory-safe, #[no_std] multi-call binary providing 303 Unix utilities

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Pegasus Heavy Industries <contact@pegasusheavy.industries>
 pkgname=armybox
-pkgver=0.3.0
+pkgver=0.4.0
 pkgrel=0
 pkgdesc="BusyBox/Toybox clone written in Rust"
 url="https://github.com/quinnjr/armybox"

--- a/packaging/archlinux/.SRCINFO
+++ b/packaging/archlinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = armybox
 	pkgdesc = BusyBox/Toybox clone written in Rust
-	pkgver = 0.3.0
+	pkgver = 0.4.0
 	pkgrel = 1
 	url = https://github.com/quinnjr/armybox
 	arch = x86_64

--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Pegasus Heavy Industries <contact@pegasusheavy.industries>
 pkgname=armybox
-pkgver=0.3.0
+pkgver=0.4.0
 pkgrel=1
 pkgdesc="BusyBox/Toybox clone written in Rust"
 arch=('x86_64' 'aarch64')

--- a/packaging/rpm/armybox.spec
+++ b/packaging/rpm/armybox.spec
@@ -1,5 +1,5 @@
 Name:           armybox
-Version:        0.3.0
+Version:        0.4.0
 Release:        1%{?dist}
 Summary:        BusyBox/Toybox clone written in Rust
 


### PR DESCRIPTION
Release bookkeeping for v0.4.0 (published to crates.io): version bumps
(armybox 0.4.0, abp 0.2.0, zstd-nostd 0.2.0), inter-crate dep updates,
CHANGELOG, Cargo.lock, man page, and packaging pkgver. Code already reviewed
and merged in #2 and #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)