### PR TITLE
fix: portable c_char, mode_t, time_t, and errno handling across targets

### DIFF
--- a/crates/abp/src/install.rs
+++ b/crates/abp/src/install.rs
@@ -835,11 +835,6 @@ fn parse_tar_mode(field: &[u8]) -> u32 {
     result
 }
 
-/// Current value of the C `errno`.
-fn errno() -> i32 {
-    unsafe { *libc::__errno_location() }
-}
-
 /// Create a directory, treating an already-existing directory as success.
 /// Returns `false` only for a genuine failure (a non-EEXIST error), so callers
 /// can propagate real problems without tripping over pre-existing directories.
@@ -852,7 +847,7 @@ fn mkdir_tracked(path: &[u8], mode: u32, rb: &mut Rollback) -> bool {
         rb.dirs.push(path.to_vec());
         return true;
     }
-    errno() == libc::EEXIST
+    io::errno() == libc::EEXIST
 }
 
 /// Create every parent directory of `path`, recording freshly-created ones in

--- a/crates/abp/src/io.rs
+++ b/crates/abp/src/io.rs
@@ -23,6 +23,47 @@ pub fn path_to_cstr(path: &[u8], buf: &mut [u8; PATH_MAX]) -> bool {
     true
 }
 
+/// Current value of the C `errno`.
+///
+/// Bionic exposes errno as `__errno()`; glibc and musl as `__errno_location()`.
+pub fn errno() -> i32 {
+    #[cfg(target_os = "android")]
+    unsafe {
+        *libc::__errno()
+    }
+    #[cfg(not(target_os = "android"))]
+    unsafe {
+        *libc::__errno_location()
+    }
+}
+
+/// Set the C `errno`.
+pub fn set_errno(value: i32) {
+    #[cfg(target_os = "android")]
+    unsafe {
+        *libc::__errno() = value;
+    }
+    #[cfg(not(target_os = "android"))]
+    unsafe {
+        *libc::__errno_location() = value;
+    }
+}
+
+/// Does `st_mode` describe a directory?
+///
+/// The `u32` parameter (with casts at the call site) sidesteps `mode_t`/`S_IFMT`
+/// width differences across glibc, musl, and Bionic.
+#[inline]
+pub fn is_dir(mode: u32) -> bool {
+    (mode & libc::S_IFMT as u32) == libc::S_IFDIR as u32
+}
+
+/// Does `st_mode` describe a regular file?
+#[inline]
+pub fn is_reg(mode: u32) -> bool {
+    (mode & libc::S_IFMT as u32) == libc::S_IFREG as u32
+}
+
 /// Write all bytes to a file descriptor
 pub fn write_all(fd: i32, buf: &[u8]) -> isize {
     let mut written = 0;
@@ -93,12 +134,13 @@ pub fn read_all(fd: i32) -> Vec<u8> {
 pub fn open(path: &[u8], flags: i32, mode: u32) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::open(path_buf.as_ptr() as *const i8, flags, mode) }
+    unsafe { libc::open(path_buf.as_ptr() as *const libc::c_char, flags, mode) }
 }
 
 /// Close a file descriptor
@@ -116,12 +158,13 @@ pub fn stat_zeroed() -> libc::stat {
 pub fn stat(path: &[u8], buf: &mut libc::stat) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::stat(path_buf.as_ptr() as *const i8, buf) }
+    unsafe { libc::stat(path_buf.as_ptr() as *const libc::c_char, buf) }
 }
 
 /// Get file status from fd
@@ -133,36 +176,39 @@ pub fn fstat(fd: i32, buf: &mut libc::stat) -> i32 {
 pub fn mkdir(path: &[u8], mode: u32) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::mkdir(path_buf.as_ptr() as *const i8, mode as libc::mode_t) }
+    unsafe { libc::mkdir(path_buf.as_ptr() as *const libc::c_char, mode as libc::mode_t) }
 }
 
 /// Remove a directory
 pub fn rmdir(path: &[u8]) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::rmdir(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::rmdir(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Unlink (remove) a file
 pub fn unlink(path: &[u8]) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::unlink(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::unlink(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Rename a file
@@ -171,6 +217,7 @@ pub fn rename(old: &[u8], new: &[u8]) -> i32 {
     let mut new_buf = [0u8; 4096];
 
     if old.len() >= old_buf.len() || new.len() >= new_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
 
@@ -179,7 +226,7 @@ pub fn rename(old: &[u8], new: &[u8]) -> i32 {
     new_buf[..new.len()].copy_from_slice(new);
     new_buf[new.len()] = 0;
 
-    unsafe { libc::rename(old_buf.as_ptr() as *const i8, new_buf.as_ptr() as *const i8) }
+    unsafe { libc::rename(old_buf.as_ptr() as *const libc::c_char, new_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Create a symlink
@@ -188,6 +235,7 @@ pub fn symlink(target: &[u8], linkpath: &[u8]) -> i32 {
     let mut link_buf = [0u8; 4096];
 
     if target.len() >= target_buf.len() || linkpath.len() >= link_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
 
@@ -196,43 +244,46 @@ pub fn symlink(target: &[u8], linkpath: &[u8]) -> i32 {
     link_buf[..linkpath.len()].copy_from_slice(linkpath);
     link_buf[linkpath.len()] = 0;
 
-    unsafe { libc::symlink(target_buf.as_ptr() as *const i8, link_buf.as_ptr() as *const i8) }
+    unsafe { libc::symlink(target_buf.as_ptr() as *const libc::c_char, link_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Change file permissions
 pub fn chmod(path: &[u8], mode: u32) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::chmod(path_buf.as_ptr() as *const i8, mode as libc::mode_t) }
+    unsafe { libc::chmod(path_buf.as_ptr() as *const libc::c_char, mode as libc::mode_t) }
 }
 
 /// Check file access permissions (POSIX access())
 pub fn access(path: &[u8], mode: i32) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return -1;
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::access(path_buf.as_ptr() as *const i8, mode) }
+    unsafe { libc::access(path_buf.as_ptr() as *const libc::c_char, mode) }
 }
 
 /// Open directory for reading
 pub fn opendir(path: &[u8]) -> *mut libc::DIR {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
+        set_errno(libc::ENAMETOOLONG);
         return ptr::null_mut();
     }
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::opendir(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::opendir(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Read directory entry

--- a/crates/abp/src/remove.rs
+++ b/crates/abp/src/remove.rs
@@ -140,7 +140,7 @@ pub(crate) fn remove_single_package(db: &Database, name: &str, purge: bool) -> b
         // Check if directory
         let mut stat_buf = io::stat_zeroed();
         if io::stat(path, &mut stat_buf) == 0 {
-            if (stat_buf.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+            if io::is_dir(stat_buf.st_mode as u32) {
                 // Try to remove directory (will fail if not empty)
                 io::rmdir(path);
             } else {

--- a/crates/abp/src/verify.rs
+++ b/crates/abp/src/verify.rs
@@ -352,7 +352,7 @@ fn compute_file_checksum(path: &[u8]) -> Option<[u8; 32]> {
         return None;
     }
 
-    if (stat_buf.st_mode & libc::S_IFMT) != libc::S_IFREG {
+    if !io::is_reg(stat_buf.st_mode as u32) {
         io::close(fd);
         return None;
     }

--- a/src/applets/archive/bzip2.rs
+++ b/src/applets/archive/bzip2.rs
@@ -265,7 +265,7 @@ fn bzip2_file(path: &[u8], keep: bool, block_size: u8) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result
@@ -307,7 +307,7 @@ fn bunzip2_file(path: &[u8], keep: bool) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result

--- a/src/applets/archive/compress.rs
+++ b/src/applets/archive/compress.rs
@@ -198,7 +198,7 @@ fn compress_file(path: &[u8], keep: bool) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result
@@ -239,7 +239,7 @@ fn decompress_file(path: &[u8], keep: bool) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result

--- a/src/applets/archive/gzip.rs
+++ b/src/applets/archive/gzip.rs
@@ -306,7 +306,7 @@ fn gzip_file(path: &[u8], keep: bool) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result
@@ -347,7 +347,7 @@ fn gunzip_file(path: &[u8], keep: bool) -> i32 {
         let mut path_z = [0u8; 256];
         let len = path.len().min(255);
         path_z[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::unlink(path_z.as_ptr() as *const i8) };
+        unsafe { libc::unlink(path_z.as_ptr() as *const libc::c_char) };
     }
 
     result

--- a/src/applets/archive/mod.rs
+++ b/src/applets/archive/mod.rs
@@ -68,7 +68,7 @@ pub(crate) fn create_parent_dirs(path: &[u8]) -> bool {
     for i in 0..len {
         if buf[i] == b'/' {
             buf[i] = 0;
-            unsafe { libc::mkdir(buf.as_ptr() as *const i8, 0o755) };
+            unsafe { libc::mkdir(buf.as_ptr() as *const libc::c_char, 0o755) };
             buf[i] = b'/';
         }
     }

--- a/src/applets/file/attrs.rs
+++ b/src/applets/file/attrs.rs
@@ -506,7 +506,7 @@ pub fn makedevs(argc: i32, argv: *const *const u8) -> i32 {
         path.push(0);
 
         let ret = unsafe {
-            libc::mknod(path.as_ptr() as *const i8, mode, dev)
+            libc::mknod(path.as_ptr() as *const libc::c_char, mode, dev)
         };
 
         if ret < 0 {
@@ -581,21 +581,21 @@ fn process_device_table(table_path: &[u8], rootdir: &[u8]) -> i32 {
                 // Directory
                 path.push(0);
                 let ret = unsafe {
-                    libc::mkdir(path.as_ptr() as *const i8, mode)
+                    libc::mkdir(path.as_ptr() as *const libc::c_char, mode)
                 };
                 if ret < 0 && crate::sys::errno() != libc::EEXIST {
                     status = 1;
                 }
                 unsafe {
-                    libc::chown(path.as_ptr() as *const i8, uid, gid);
+                    libc::chown(path.as_ptr() as *const libc::c_char, uid, gid);
                 }
             }
             b"f" => {
                 // File - just set permissions
                 path.push(0);
                 unsafe {
-                    libc::chmod(path.as_ptr() as *const i8, mode);
-                    libc::chown(path.as_ptr() as *const i8, uid, gid);
+                    libc::chmod(path.as_ptr() as *const libc::c_char, mode);
+                    libc::chown(path.as_ptr() as *const libc::c_char, uid, gid);
                 }
             }
             b"c" | b"b" => {
@@ -608,8 +608,8 @@ fn process_device_table(table_path: &[u8], rootdir: &[u8]) -> i32 {
 
                     path.push(0);
                     unsafe {
-                        libc::mknod(path.as_ptr() as *const i8, dev_mode, dev);
-                        libc::chown(path.as_ptr() as *const i8, uid, gid);
+                        libc::mknod(path.as_ptr() as *const libc::c_char, dev_mode, dev);
+                        libc::chown(path.as_ptr() as *const libc::c_char, uid, gid);
                     }
                 }
             }
@@ -681,8 +681,8 @@ pub fn setfattr(argc: i32, argv: *const *const u8) -> i32 {
 
             let ret = unsafe {
                 libc::removexattr(
-                    path_buf.as_ptr() as *const i8,
-                    name_buf.as_ptr() as *const i8,
+                    path_buf.as_ptr() as *const libc::c_char,
+                    name_buf.as_ptr() as *const libc::c_char,
                 )
             };
             if ret < 0 {
@@ -700,8 +700,8 @@ pub fn setfattr(argc: i32, argv: *const *const u8) -> i32 {
 
             let ret = unsafe {
                 libc::setxattr(
-                    path_buf.as_ptr() as *const i8,
-                    name_buf.as_ptr() as *const i8,
+                    path_buf.as_ptr() as *const libc::c_char,
+                    name_buf.as_ptr() as *const libc::c_char,
                     value.as_ptr() as *const libc::c_void,
                     value.len(),
                     0,

--- a/src/applets/file/chgrp.rs
+++ b/src/applets/file/chgrp.rs
@@ -103,7 +103,7 @@ fn lookup_gid(name: &[u8]) -> Option<u32> {
     buf[..len].copy_from_slice(&name[..len]);
     buf[len] = 0;
 
-    let gr = unsafe { libc::getgrnam(buf.as_ptr() as *const i8) };
+    let gr = unsafe { libc::getgrnam(buf.as_ptr() as *const libc::c_char) };
     if gr.is_null() {
         None
     } else {
@@ -117,9 +117,9 @@ fn chgrp_path(path: &[u8], gid: u32, no_deref: bool, recursive: bool) -> i32 {
         let mut buf = [0u8; 4096];
         let len = core::cmp::min(path.len(), buf.len() - 1);
         buf[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::lchown(buf.as_ptr() as *const i8, u32::MAX, gid) }
+        unsafe { libc::lchown(buf.as_ptr() as *const libc::c_char, u32::MAX, gid) }
     } else {
-        unsafe { libc::chown(path.as_ptr() as *const i8, u32::MAX, gid) }
+        unsafe { libc::chown(path.as_ptr() as *const libc::c_char, u32::MAX, gid) }
     };
 
     if ret < 0 {
@@ -129,7 +129,7 @@ fn chgrp_path(path: &[u8], gid: u32, no_deref: bool, recursive: bool) -> i32 {
 
     if recursive {
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
-        if io::stat(path, &mut st) == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+        if io::stat(path, &mut st) == 0 && (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
             return chgrp_recursive(path, gid, no_deref);
         }
     }

--- a/src/applets/file/chmod.rs
+++ b/src/applets/file/chmod.rs
@@ -265,7 +265,7 @@ fn chmod_path(path: &[u8], spec: &ModeSpec, recursive: bool) -> i32 {
         return 1;
     }
 
-    let is_dir = (st.st_mode & libc::S_IFMT) == libc::S_IFDIR;
+    let is_dir = (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32;
     let new_mode = apply_mode(st.st_mode & 0o7777, spec, is_dir);
 
     if io::chmod(path, new_mode) < 0 {

--- a/src/applets/file/chown.rs
+++ b/src/applets/file/chown.rs
@@ -146,7 +146,7 @@ fn lookup_uid(name: &[u8]) -> Option<u32> {
     buf[..len].copy_from_slice(&name[..len]);
     buf[len] = 0;
 
-    let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const i8) };
+    let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const libc::c_char) };
     if pw.is_null() {
         None
     } else {
@@ -161,7 +161,7 @@ fn lookup_gid(name: &[u8]) -> Option<u32> {
     buf[..len].copy_from_slice(&name[..len]);
     buf[len] = 0;
 
-    let gr = unsafe { libc::getgrnam(buf.as_ptr() as *const i8) };
+    let gr = unsafe { libc::getgrnam(buf.as_ptr() as *const libc::c_char) };
     if gr.is_null() {
         None
     } else {
@@ -176,9 +176,9 @@ fn chown_path(path: &[u8], uid: u32, gid: u32, no_deref: bool, recursive: bool) 
         let mut buf = [0u8; 4096];
         let len = core::cmp::min(path.len(), buf.len() - 1);
         buf[..len].copy_from_slice(&path[..len]);
-        unsafe { libc::lchown(buf.as_ptr() as *const i8, uid, gid) }
+        unsafe { libc::lchown(buf.as_ptr() as *const libc::c_char, uid, gid) }
     } else {
-        unsafe { libc::chown(path.as_ptr() as *const i8, uid, gid) }
+        unsafe { libc::chown(path.as_ptr() as *const libc::c_char, uid, gid) }
     };
 
     if ret < 0 {
@@ -188,7 +188,7 @@ fn chown_path(path: &[u8], uid: u32, gid: u32, no_deref: bool, recursive: bool) 
 
     if recursive {
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
-        if io::stat(path, &mut st) == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+        if io::stat(path, &mut st) == 0 && (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
             return chown_recursive(path, uid, gid, no_deref);
         }
     }

--- a/src/applets/file/cp.rs
+++ b/src/applets/file/cp.rs
@@ -124,7 +124,7 @@ fn is_directory(path: &[u8]) -> bool {
     if io::stat(path, &mut st) < 0 {
         return false;
     }
-    (st.st_mode & libc::S_IFMT) == libc::S_IFDIR
+    (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32
 }
 
 /// Build destination path by appending basename of source to dest directory
@@ -185,7 +185,7 @@ fn copy_item(
     // links instead of being followed.
     if no_deref {
         let mut lst: libc::stat = unsafe { core::mem::zeroed() };
-        if io::lstat(src, &mut lst) == 0 && (lst.st_mode & libc::S_IFMT) == libc::S_IFLNK {
+        if io::lstat(src, &mut lst) == 0 && (lst.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFLNK as u32 {
             return copy_symlink(src, dest, force);
         }
     }
@@ -196,7 +196,7 @@ fn copy_item(
         return 1;
     }
 
-    if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+    if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
         if !recursive {
             io::write_str(2, b"cp: omitting directory '");
             io::write_all(2, src);
@@ -305,7 +305,7 @@ fn copy_file_opts(src: &[u8], dest: &[u8], force: bool, preserve: bool) -> i32 {
         // Preserve ownership (may fail if not root)
         unsafe {
             libc::chown(
-                dest.as_ptr() as *const i8,
+                dest.as_ptr() as *const libc::c_char,
                 src_st.st_uid,
                 src_st.st_gid,
             );
@@ -323,7 +323,7 @@ fn copy_file_opts(src: &[u8], dest: &[u8], force: bool, preserve: bool) -> i32 {
             },
         ];
         unsafe {
-            libc::utimes(dest.as_ptr() as *const i8, times.as_ptr());
+            libc::utimes(dest.as_ptr() as *const libc::c_char, times.as_ptr());
         }
     }
 
@@ -409,14 +409,14 @@ fn copy_directory(
         if io::stat(src, &mut src_st) == 0 {
             io::chmod(dest, src_st.st_mode & 0o7777);
             unsafe {
-                libc::chown(dest.as_ptr() as *const i8, src_st.st_uid, src_st.st_gid);
+                libc::chown(dest.as_ptr() as *const libc::c_char, src_st.st_uid, src_st.st_gid);
             }
             let times = [
                 libc::timeval { tv_sec: src_st.st_atime, tv_usec: 0 },
                 libc::timeval { tv_sec: src_st.st_mtime, tv_usec: 0 },
             ];
             unsafe {
-                libc::utimes(dest.as_ptr() as *const i8, times.as_ptr());
+                libc::utimes(dest.as_ptr() as *const libc::c_char, times.as_ptr());
             }
         }
     }

--- a/src/applets/file/file_cmd.rs
+++ b/src/applets/file/file_cmd.rs
@@ -35,14 +35,14 @@ pub fn file(argc: i32, argv: *const *const u8) -> i32 {
                 continue;
             }
 
-            match st.st_mode & libc::S_IFMT {
-                libc::S_IFDIR => { io::write_str(1, b"directory\n"); }
-                libc::S_IFLNK => { io::write_str(1, b"symbolic link\n"); }
-                libc::S_IFIFO => { io::write_str(1, b"fifo (named pipe)\n"); }
-                libc::S_IFSOCK => { io::write_str(1, b"socket\n"); }
-                libc::S_IFBLK => { io::write_str(1, b"block special\n"); }
-                libc::S_IFCHR => { io::write_str(1, b"character special\n"); }
-                libc::S_IFREG => {
+            match st.st_mode as u32 & libc::S_IFMT as u32 {
+                t if t == libc::S_IFDIR as u32 => { io::write_str(1, b"directory\n"); }
+                t if t == libc::S_IFLNK as u32 => { io::write_str(1, b"symbolic link\n"); }
+                t if t == libc::S_IFIFO as u32 => { io::write_str(1, b"fifo (named pipe)\n"); }
+                t if t == libc::S_IFSOCK as u32 => { io::write_str(1, b"socket\n"); }
+                t if t == libc::S_IFBLK as u32 => { io::write_str(1, b"block special\n"); }
+                t if t == libc::S_IFCHR as u32 => { io::write_str(1, b"character special\n"); }
+                t if t == libc::S_IFREG as u32 => {
                     // Check magic bytes
                     let fd = io::open(path, libc::O_RDONLY, 0);
                     if fd >= 0 {

--- a/src/applets/file/find_cmd.rs
+++ b/src/applets/file/find_cmd.rs
@@ -161,7 +161,7 @@ fn process(
         return;
     }
 
-    let is_dir = (st.st_mode & libc::S_IFMT) == libc::S_IFDIR;
+    let is_dir = (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32;
     let mut can_descend = is_dir && depth < cfg.maxdepth;
 
     // Bound genuine recursion depth so a pathologically deep tree stops the
@@ -382,7 +382,7 @@ fn run_exec(template: &[&[u8]], path: &[u8], ret: &mut i32) -> bool {
                 cstrings.push(cs);
             }
         }
-        let ptrs: Vec<*const i8> = cstrings
+        let ptrs: Vec<*const libc::c_char> = cstrings
             .iter()
             .map(|s| s.as_ptr())
             .chain(core::iter::once(core::ptr::null()))
@@ -405,7 +405,7 @@ fn run_exec(template: &[&[u8]], path: &[u8], ret: &mut i32) -> bool {
 
 /// Write a `find: 'PATH': strerror` diagnostic to stderr.
 fn diag(path: &[u8]) {
-    let errno = unsafe { *libc::__errno_location() };
+    let errno = crate::sys::errno();
     io::write_str(2, b"find: '");
     io::write_all(2, path);
     io::write_str(2, b"': ");

--- a/src/applets/file/ln.rs
+++ b/src/applets/file/ln.rs
@@ -70,7 +70,7 @@ pub fn ln(argc: i32, argv: *const *const u8) -> i32 {
     // of being dereferenced.
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
     let stat_ret = if no_deref { io::lstat(last, &mut st) } else { io::stat(last, &mut st) };
-    let last_is_dir = stat_ret == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFDIR;
+    let last_is_dir = stat_ret == 0 && (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32;
 
     if last_is_dir {
         // ln [-fs] source... target_dir

--- a/src/applets/file/ls.rs
+++ b/src/applets/file/ls.rs
@@ -249,7 +249,7 @@ pub fn ls(argc: i32, argv: *const *const u8) -> i32 {
             exit_code = 1;
             continue;
         }
-        let is_dir = (st.st_mode & libc::S_IFMT) == libc::S_IFDIR;
+        let is_dir = (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32;
         if is_dir && !flags.dir_only {
             dirs.push(op);
         } else {

--- a/src/applets/file/mkdir.rs
+++ b/src/applets/file/mkdir.rs
@@ -87,7 +87,7 @@ pub(crate) fn mkdir_parents(path: &[u8], mode: u32) -> i32 {
         // Check if it already exists and is a directory
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
         if io::stat(&partial[..len], &mut st) == 0 {
-            if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+            if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
                 return 0; // Already exists as directory, OK
             }
         }

--- a/src/applets/file/mkfifo.rs
+++ b/src/applets/file/mkfifo.rs
@@ -176,7 +176,7 @@ pub fn mkfifo(argc: i32, argv: *const *const u8) -> i32 {
 
     let mut exit_code = 0;
     for path in files {
-        if unsafe { libc::mkfifo(path.as_ptr() as *const i8, mode) } < 0 {
+        if unsafe { libc::mkfifo(path.as_ptr() as *const libc::c_char, mode) } < 0 {
             sys::perror(path);
             exit_code = 1;
         }

--- a/src/applets/file/mknod.rs
+++ b/src/applets/file/mknod.rs
@@ -60,7 +60,7 @@ pub fn mknod(argc: i32, argv: *const *const u8) -> i32 {
         return 1;
     };
 
-    if unsafe { libc::mknod(path.as_ptr() as *const i8, mode, dev) } < 0 {
+    if unsafe { libc::mknod(path.as_ptr() as *const libc::c_char, mode, dev) } < 0 {
         sys::perror(path);
         return 1;
     }

--- a/src/applets/file/mv.rs
+++ b/src/applets/file/mv.rs
@@ -97,7 +97,7 @@ fn is_directory(path: &[u8]) -> bool {
     if io::stat(path, &mut st) < 0 {
         return false;
     }
-    (st.st_mode & libc::S_IFMT) == libc::S_IFDIR
+    (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32
 }
 
 /// Build destination path by appending basename of source to dest directory
@@ -140,7 +140,7 @@ fn move_item(src: &[u8], dest: &[u8], force: bool) -> i32 {
     if force {
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
         if io::lstat(dest, &mut st) == 0 {
-            if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+            if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
                 // Can't force-remove a directory this way
             } else {
                 let _ = io::unlink(dest);
@@ -161,7 +161,7 @@ fn move_item(src: &[u8], dest: &[u8], force: bool) -> i32 {
         return 1;
     }
 
-    if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+    if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
         // For directories, we need recursive copy then remove
         if copy_directory(src, dest) != 0 {
             return 1;
@@ -277,7 +277,7 @@ fn copy_directory(src: &[u8], dest: &[u8]) -> i32 {
 
                 let mut st: libc::stat = unsafe { core::mem::zeroed() };
                 if io::stat(&src_path[..src_len], &mut st) == 0 {
-                    if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+                    if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
                         if copy_directory(&src_path[..src_len], &dest_path[..dest_len]) != 0 {
                             exit_code = 1;
                         }
@@ -300,7 +300,7 @@ fn remove_recursive(path: &[u8]) {
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
     if io::stat(path, &mut st) < 0 { return; }
 
-    if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+    if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
         let fd = io::open(path, libc::O_RDONLY | libc::O_DIRECTORY, 0);
         if fd < 0 { return; }
 

--- a/src/applets/file/pwd.rs
+++ b/src/applets/file/pwd.rs
@@ -61,7 +61,7 @@ pub fn pwd(argc: i32, argv: *const *const u8) -> i32 {
     }
 
     let mut buf = [0u8; 4096];
-    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut i8, buf.len()) };
+    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
     if !ret.is_null() {
         io::write_all(1, &buf[..io::strlen_arr(&buf)]);
         io::write_str(1, b"\n");

--- a/src/applets/file/rm.rs
+++ b/src/applets/file/rm.rs
@@ -86,7 +86,7 @@ fn remove_file(path: &[u8], force: bool) -> i32 {
     // Check if it's a directory
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
     if io::lstat(path, &mut st) == 0 {
-        if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+        if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
             if !force {
                 io::write_str(2, b"rm: cannot remove '");
                 io::write_all(2, path);
@@ -125,7 +125,7 @@ fn remove_recursive(path: &[u8], force: bool) -> i32 {
     }
 
     // If it's a symlink or regular file, just unlink it
-    if (st.st_mode & libc::S_IFMT) != libc::S_IFDIR {
+    if (st.st_mode as u32 & libc::S_IFMT as u32) != libc::S_IFDIR as u32 {
         if io::unlink(path) < 0 {
             if !force {
                 sys::perror(path);

--- a/src/applets/file/touch.rs
+++ b/src/applets/file/touch.rs
@@ -89,7 +89,7 @@ pub fn touch(argc: i32, argv: *const *const u8) -> i32 {
             io::write_str(2, b"'\n");
             return 1;
         }
-        Some((st.st_atime, st.st_mtime))
+        Some((st.st_atime as i64, st.st_mtime as i64))
     } else if let Some(ts) = time_str {
         match parse_touch_time(ts) {
             Some((sec, _)) => Some((sec, sec)),
@@ -131,7 +131,7 @@ pub fn touch(argc: i32, argv: *const *const u8) -> i32 {
                 None => {
                     // Current time - use utimes with null
                     if access_only && mod_only {
-                        if unsafe { libc::utimes(path.as_ptr() as *const i8, core::ptr::null()) } < 0 {
+                        if unsafe { libc::utimes(path.as_ptr() as *const libc::c_char, core::ptr::null()) } < 0 {
                             sys::perror(path);
                             exit_code = 1;
                         }
@@ -156,7 +156,7 @@ pub fn touch(argc: i32, argv: *const *const u8) -> i32 {
                                 tv_usec: 0,
                             },
                         ];
-                        if unsafe { libc::utimes(path.as_ptr() as *const i8, times.as_ptr()) } < 0 {
+                        if unsafe { libc::utimes(path.as_ptr() as *const libc::c_char, times.as_ptr()) } < 0 {
                             sys::perror(path);
                             exit_code = 1;
                         }
@@ -173,15 +173,15 @@ pub fn touch(argc: i32, argv: *const *const u8) -> i32 {
 
                     let times = [
                         libc::timeval {
-                            tv_sec: if access_only { atime } else { st2.st_atime },
+                            tv_sec: if access_only { atime as libc::time_t } else { st2.st_atime },
                             tv_usec: 0,
                         },
                         libc::timeval {
-                            tv_sec: if mod_only { mtime } else { st2.st_mtime },
+                            tv_sec: if mod_only { mtime as libc::time_t } else { st2.st_mtime },
                             tv_usec: 0,
                         },
                     ];
-                    if unsafe { libc::utimes(path.as_ptr() as *const i8, times.as_ptr()) } < 0 {
+                    if unsafe { libc::utimes(path.as_ptr() as *const libc::c_char, times.as_ptr()) } < 0 {
                         sys::perror(path);
                         exit_code = 1;
                     }
@@ -207,7 +207,7 @@ fn parse_touch_time(s: &[u8]) -> Option<(i64, i64)> {
     let (year, month, day, hour, min) = match main.len() {
         8 => {
             // MMDDhhmm - use current year
-            let mut now: i64 = 0;
+            let mut now: libc::time_t = 0;
             unsafe { libc::time(&mut now) };
             let tm = unsafe { libc::localtime(&now) };
             let year = unsafe { (*tm).tm_year + 1900 } as i64;
@@ -256,7 +256,7 @@ fn parse_touch_time(s: &[u8]) -> Option<(i64, i64)> {
         return None;
     }
 
-    Some((epoch, 0))
+    Some((epoch as i64, 0))
 }
 
 /// Parse a 2-digit decimal number

--- a/src/applets/file/truncate.rs
+++ b/src/applets/file/truncate.rs
@@ -85,7 +85,7 @@ pub fn truncate(argc: i32, argv: *const *const u8) -> i32 {
                 }
             }
 
-            if unsafe { libc::truncate(arg.as_ptr() as *const i8, size) } < 0 {
+            if unsafe { libc::truncate(arg.as_ptr() as *const libc::c_char, size) } < 0 {
                 sys::perror(arg);
                 exit_code = 1;
             }

--- a/src/applets/file/xargs.rs
+++ b/src/applets/file/xargs.rs
@@ -536,7 +536,7 @@ fn exec_command(cmd: &[u8], args: &[&[u8]]) -> ! {
         }
     }
 
-    let ptrs: Vec<*const i8> = cstrings.iter()
+    let ptrs: Vec<*const libc::c_char> = cstrings.iter()
         .map(|s| s.as_ptr())
         .chain(core::iter::once(core::ptr::null()))
         .collect();
@@ -548,7 +548,7 @@ fn exec_command(cmd: &[u8], args: &[&[u8]]) -> ! {
     io::write_all(2, cmd);
     io::write_str(2, b": ");
 
-    let errno = unsafe { *libc::__errno_location() };
+    let errno = crate::sys::errno();
     if errno == libc::ENOENT {
         io::write_str(2, b"command not found\n");
         unsafe { libc::_exit(127); }

--- a/src/applets/init.rs
+++ b/src/applets/init.rs
@@ -67,15 +67,15 @@ fn run_command(cmd: &[u8], wait_for: bool) -> i32 {
         cmd_buf[..cmd_len].copy_from_slice(&cmd[..cmd_len]);
         cmd_buf[cmd_len] = 0;
 
-        let argv: [*const i8; 4] = [
-            sh_path.as_ptr() as *const i8,
-            dash_c.as_ptr() as *const i8,
-            cmd_buf.as_ptr() as *const i8,
+        let argv: [*const libc::c_char; 4] = [
+            sh_path.as_ptr() as *const libc::c_char,
+            dash_c.as_ptr() as *const libc::c_char,
+            cmd_buf.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execv(sh_path.as_ptr() as *const i8, argv.as_ptr());
+            libc::execv(sh_path.as_ptr() as *const libc::c_char, argv.as_ptr());
         }
 
         // If exec fails, try running command directly
@@ -117,9 +117,9 @@ fn mount_if_needed(source: &[u8], target: &[u8], fstype: &[u8]) {
     // Try to mount
     let ret = unsafe {
         libc::mount(
-            source_buf.as_ptr() as *const i8,
-            target_buf.as_ptr() as *const i8,
-            fstype_buf.as_ptr() as *const i8,
+            source_buf.as_ptr() as *const libc::c_char,
+            target_buf.as_ptr() as *const libc::c_char,
+            fstype_buf.as_ptr() as *const libc::c_char,
             0,
             core::ptr::null(),
         )
@@ -158,13 +158,13 @@ pub fn init(_argc: i32, _argv: *const *const u8) -> i32 {
         if pid == 0 {
             // Child - exec shell
             let sh = b"/bin/sh\0";
-            let argv: [*const i8; 2] = [
-                sh.as_ptr() as *const i8,
+            let argv: [*const libc::c_char; 2] = [
+                sh.as_ptr() as *const libc::c_char,
                 core::ptr::null(),
             ];
             unsafe {
                 libc::setsid();
-                libc::execv(sh.as_ptr() as *const i8, argv.as_ptr());
+                libc::execv(sh.as_ptr() as *const libc::c_char, argv.as_ptr());
             }
             io::exit(1);
         }
@@ -212,13 +212,13 @@ pub fn init(_argc: i32, _argv: *const *const u8) -> i32 {
             let pid = io::fork();
             if pid == 0 {
                 let sh = b"/bin/sh\0";
-                let argv: [*const i8; 2] = [
-                    sh.as_ptr() as *const i8,
+                let argv: [*const libc::c_char; 2] = [
+                    sh.as_ptr() as *const libc::c_char,
                     core::ptr::null(),
                 ];
                 unsafe {
                     libc::setsid();
-                    libc::execv(sh.as_ptr() as *const i8, argv.as_ptr());
+                    libc::execv(sh.as_ptr() as *const libc::c_char, argv.as_ptr());
                 }
                 io::exit(1);
             }
@@ -469,13 +469,13 @@ pub fn getty(argc: i32, argv: *const *const u8) -> i32 {
     // into an unauthenticated shell.
     let login_path = b"/bin/login\0";
     let login_name = b"login\0";
-    let argv_login: [*const i8; 2] = [
-        login_name.as_ptr() as *const i8,
+    let argv_login: [*const libc::c_char; 2] = [
+        login_name.as_ptr() as *const libc::c_char,
         core::ptr::null(),
     ];
 
     unsafe {
-        libc::execv(login_path.as_ptr() as *const i8, argv_login.as_ptr());
+        libc::execv(login_path.as_ptr() as *const libc::c_char, argv_login.as_ptr());
     }
 
     io::write_str(2, b"getty: exec /bin/login failed\n");
@@ -517,13 +517,13 @@ pub fn sulogin(_argc: i32, _argv: *const *const u8) -> i32 {
 
     // Spawn shell
     let sh = b"/bin/sh\0";
-    let argv: [*const i8; 2] = [
-        sh.as_ptr() as *const i8,
+    let argv: [*const libc::c_char; 2] = [
+        sh.as_ptr() as *const libc::c_char,
         core::ptr::null(),
     ];
 
     unsafe {
-        libc::execv(sh.as_ptr() as *const i8, argv.as_ptr());
+        libc::execv(sh.as_ptr() as *const libc::c_char, argv.as_ptr());
     }
 
     1
@@ -540,13 +540,13 @@ pub fn oneit(argc: i32, argv: *const *const u8) -> i32 {
     // Build argv for the command
     #[cfg(all(feature = "oneit", feature = "alloc"))]
     {
-        let mut args: Vec<*const i8> = Vec::new();
+        let mut args: Vec<*const libc::c_char> = Vec::new();
         for i in 1..argc {
             if let Some(arg) = unsafe { get_arg(argv, i) } {
                 // Need null-terminated string
                 let mut buf = alloc::vec![0u8; arg.len() + 1];
                 buf[..arg.len()].copy_from_slice(arg);
-                args.push(buf.leak().as_ptr() as *const i8);
+                args.push(buf.leak().as_ptr() as *const libc::c_char);
             }
         }
         args.push(core::ptr::null());
@@ -591,23 +591,23 @@ pub fn switch_root(argc: i32, argv: *const *const u8) -> i32 {
     root_buf[..rlen].copy_from_slice(&new_root[..rlen]);
 
     unsafe {
-        if libc::chdir(root_buf.as_ptr() as *const i8) != 0 {
+        if libc::chdir(root_buf.as_ptr() as *const libc::c_char) != 0 {
             io::write_str(2, b"switch_root: chdir failed\n");
             return 1;
         }
 
-        if libc::mount(root_buf.as_ptr() as *const i8, b"/\0".as_ptr() as *const i8,
+        if libc::mount(root_buf.as_ptr() as *const libc::c_char, b"/\0".as_ptr() as *const libc::c_char,
                        core::ptr::null(), libc::MS_MOVE, core::ptr::null()) != 0 {
             io::write_str(2, b"switch_root: mount --move failed\n");
             return 1;
         }
 
-        if libc::chroot(b".\0".as_ptr() as *const i8) != 0 {
+        if libc::chroot(b".\0".as_ptr() as *const libc::c_char) != 0 {
             io::write_str(2, b"switch_root: chroot failed\n");
             return 1;
         }
 
-        if libc::chdir(b"/\0".as_ptr() as *const i8) != 0 {
+        if libc::chdir(b"/\0".as_ptr() as *const libc::c_char) != 0 {
             io::write_str(2, b"switch_root: chdir / failed\n");
             return 1;
         }
@@ -618,13 +618,13 @@ pub fn switch_root(argc: i32, argv: *const *const u8) -> i32 {
     let ilen = core::cmp::min(new_init.len(), init_buf.len() - 1);
     init_buf[..ilen].copy_from_slice(&new_init[..ilen]);
 
-    let argv_init: [*const i8; 2] = [
-        init_buf.as_ptr() as *const i8,
+    let argv_init: [*const libc::c_char; 2] = [
+        init_buf.as_ptr() as *const libc::c_char,
         core::ptr::null(),
     ];
 
     unsafe {
-        libc::execv(init_buf.as_ptr() as *const i8, argv_init.as_ptr());
+        libc::execv(init_buf.as_ptr() as *const libc::c_char, argv_init.as_ptr());
     }
 
     io::write_str(2, b"switch_root: exec failed\n");

--- a/src/applets/misc/getconf.rs
+++ b/src/applets/misc/getconf.rs
@@ -92,14 +92,14 @@ pub fn getconf(argc: i32, argv: *const *const u8) -> i32 {
         let mut cbuf = alloc::vec::Vec::with_capacity(p.len() + 1);
         cbuf.extend_from_slice(p);
         cbuf.push(0);
-        let val = unsafe { libc::pathconf(cbuf.as_ptr() as *const i8, pc) };
+        let val = unsafe { libc::pathconf(cbuf.as_ptr() as *const libc::c_char, pc) };
         // pathconf returns -1 for "no limit"; POSIX getconf prints it.
-        write_signed(1, val);
+        write_signed(1, val as i64);
         io::write_str(1, b"\n");
         0
     } else if let Some(sc) = sysconf_var(name) {
         let val = unsafe { libc::sysconf(sc) };
-        write_signed(1, val);
+        write_signed(1, val as i64);
         io::write_str(1, b"\n");
         0
     } else {

--- a/src/applets/misc/screen.rs
+++ b/src/applets/misc/screen.rs
@@ -90,7 +90,7 @@ pub fn screen_list_sessions() -> i32 {
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
         if io::stat(&path_buf[..idx], &mut st) == 0 {
             // Check if socket (S_IFSOCK)
-            if (st.st_mode & libc::S_IFMT) == libc::S_IFSOCK {
+            if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFSOCK as u32 {
                 io::write_str(1, b"\t");
                 io::write_all(1, &name[..len]);
                 io::write_str(1, b"\t(Detached)\n");
@@ -155,7 +155,7 @@ pub fn screen_detach(session_name: &[u8]) -> i32 {
 
         // Copy path to sun_path
         for i in 0..idx.min(107) {
-            addr.sun_path[i] = sock_path[i] as i8;
+            addr.sun_path[i] = sock_path[i] as libc::c_char;
         }
 
         let ret = unsafe {
@@ -236,7 +236,7 @@ pub fn screen_reattach(session_name: &[u8]) -> i32 {
         addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
 
         for i in 0..idx.min(107) {
-            addr.sun_path[i] = sock_path[i] as i8;
+            addr.sun_path[i] = sock_path[i] as libc::c_char;
         }
 
         let ret = unsafe {
@@ -437,7 +437,7 @@ pub fn screen_new_session(session_name: Option<&[u8]>) -> i32 {
     addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
 
     for i in 0..sock_path_len.min(107) {
-        addr.sun_path[i] = sock_path[i] as i8;
+        addr.sun_path[i] = sock_path[i] as libc::c_char;
     }
 
     let ret = unsafe {
@@ -522,7 +522,7 @@ pub fn screen_new_session(session_name: Option<&[u8]>) -> i32 {
         shell_path.push(0);
 
         if let Ok(shell_cstr) = CString::from_vec_with_nul(shell_path) {
-            let args: [*const i8; 2] = [shell_cstr.as_ptr(), core::ptr::null()];
+            let args: [*const libc::c_char; 2] = [shell_cstr.as_ptr(), core::ptr::null()];
             unsafe {
                 libc::execv(shell_cstr.as_ptr(), args.as_ptr());
             }

--- a/src/applets/misc/test.rs
+++ b/src/applets/misc/test.rs
@@ -178,7 +178,7 @@ fn unary(op: &[u8], arg: &[u8]) -> Result<bool, ()> {
             // Symlink test operates on the link itself.
             let mut st = io::stat_zeroed();
             let ok = io::lstat(arg, &mut st) == 0;
-            return Ok(ok && (st.st_mode & libc::S_IFMT) == libc::S_IFLNK);
+            return Ok(ok && (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFLNK as u32);
         }
         _ => {}
     }

--- a/src/applets/misc/time.rs
+++ b/src/applets/misc/time.rs
@@ -128,7 +128,7 @@ pub fn time(argc: i32, argv: *const *const u8) -> i32 {
             }
         }
 
-        let ptrs: Vec<*const i8> = args.iter()
+        let ptrs: Vec<*const libc::c_char> = args.iter()
             .map(|s| s.as_ptr())
             .chain(core::iter::once(core::ptr::null()))
             .collect();

--- a/src/applets/misc/ts.rs
+++ b/src/applets/misc/ts.rs
@@ -92,7 +92,7 @@ pub fn ts(argc: i32, argv: *const *const u8) -> i32 {
             io::write_all(1, s);
         } else {
             // Format wall clock time
-            format_timestamp(now, format);
+            format_timestamp(now as i64, format);
         }
 
         io::write_str(1, b" ");
@@ -106,7 +106,8 @@ fn format_timestamp(time: i64, _format: Option<&[u8]>) {
     // Simple ISO-ish format: YYYY-MM-DD HH:MM:SS
     let mut tm: libc::tm = unsafe { core::mem::zeroed() };
     unsafe {
-        libc::localtime_r(&time, &mut tm);
+        let t = time as libc::time_t;
+        libc::localtime_r(&t, &mut tm);
     }
 
     let mut buf = [0u8; 8];

--- a/src/applets/misc/which.rs
+++ b/src/applets/misc/which.rs
@@ -22,7 +22,7 @@ pub fn which(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 { return 1; }
 
     let cmd = unsafe { get_arg(argv, 1).unwrap() };
-    let path_env = unsafe { libc::getenv(b"PATH\0".as_ptr() as *const i8) };
+    let path_env = unsafe { libc::getenv(b"PATH\0".as_ptr() as *const libc::c_char) };
 
     if path_env.is_null() { return 1; }
 
@@ -35,7 +35,7 @@ pub fn which(argc: i32, argv: *const *const u8) -> i32 {
         full_path[len] = b'/'; len += 1;
         for &c in cmd { full_path[len] = c; len += 1; }
 
-        if unsafe { libc::access(full_path.as_ptr() as *const i8, libc::X_OK) } == 0 {
+        if unsafe { libc::access(full_path.as_ptr() as *const libc::c_char, libc::X_OK) } == 0 {
             io::write_all(1, &full_path[..len]);
             io::write_str(1, b"\n");
             return 0;

--- a/src/applets/network/arping.rs
+++ b/src/applets/network/arping.rs
@@ -110,7 +110,7 @@ pub fn arping(argc: i32, argv: *const *const u8) -> i32 {
 
     // Set timeout
     let tv = libc::timeval {
-        tv_sec: timeout as i64,
+        tv_sec: timeout as libc::time_t,
         tv_usec: 0,
     };
     unsafe {

--- a/src/applets/network/brctl.rs
+++ b/src/applets/network/brctl.rs
@@ -562,7 +562,7 @@ fn get_if_index(sock: i32, iface: &[u8]) -> Option<libc::c_int> {
 
 #[cfg(target_os = "linux")]
 fn print_errno() {
-    let errno = unsafe { *libc::__errno_location() };
+    let errno = crate::sys::errno();
     let msg = match errno {
         libc::EEXIST => b"already exists" as &[u8],
         libc::ENOENT => b"not found" as &[u8],

--- a/src/applets/network/ftpget.rs
+++ b/src/applets/network/ftpget.rs
@@ -160,7 +160,7 @@ fn resolve_host(host: &[u8], port: u16) -> Option<libc::sockaddr_in> {
     hints.ai_socktype = libc::SOCK_STREAM;
 
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
-    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const i8, core::ptr::null(), &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const libc::c_char, core::ptr::null(), &hints, &mut res) } != 0 {
         return None;
     }
 

--- a/src/applets/network/ftpput.rs
+++ b/src/applets/network/ftpput.rs
@@ -174,7 +174,7 @@ fn resolve_host(host: &[u8], port: u16) -> Option<libc::sockaddr_in> {
     hints.ai_socktype = libc::SOCK_STREAM;
 
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
-    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const i8, core::ptr::null(), &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const libc::c_char, core::ptr::null(), &hints, &mut res) } != 0 {
         return None;
     }
 

--- a/src/applets/network/host.rs
+++ b/src/applets/network/host.rs
@@ -33,7 +33,7 @@ pub fn host(argc: i32, argv: *const *const u8) -> i32 {
     hints.ai_family = libc::AF_UNSPEC;
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
 
-    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const i8, core::ptr::null(), &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const libc::c_char, core::ptr::null(), &hints, &mut res) } != 0 {
         io::write_str(2, b"host: ");
         io::write_all(2, hostname);
         io::write_str(2, b" not found\n");

--- a/src/applets/network/httpd.rs
+++ b/src/applets/network/httpd.rs
@@ -391,7 +391,7 @@ fn is_directory(path: &[u8]) -> bool {
     if io::stat(path, &mut stat_buf) < 0 {
         return false;
     }
-    (stat_buf.st_mode & libc::S_IFMT) == libc::S_IFDIR
+    (stat_buf.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32
 }
 
 fn get_mime_type(path: &[u8]) -> &'static [u8] {

--- a/src/applets/network/ifdown.rs
+++ b/src/applets/network/ifdown.rs
@@ -282,10 +282,10 @@ fn deconfigure_interface_direct(iface: &[u8], verbose: bool) -> i32 {
     result
 }
 
-fn copy_iface_name(dest: &mut [i8; 16], src: &[u8]) {
+fn copy_iface_name(dest: &mut [libc::c_char; 16], src: &[u8]) {
     let len = src.len().min(15);
     for i in 0..len {
-        dest[i] = src[i] as i8;
+        dest[i] = src[i] as libc::c_char;
     }
     dest[len] = 0;
 }
@@ -305,15 +305,15 @@ fn run_command(cmd: &[u8]) -> i32 {
         let sh = b"/bin/sh\0";
         let c_flag = b"-c\0";
 
-        let argv: [*const i8; 4] = [
-            sh.as_ptr() as *const i8,
-            c_flag.as_ptr() as *const i8,
-            cmd_cstr.as_ptr() as *const i8,
+        let argv: [*const libc::c_char; 4] = [
+            sh.as_ptr() as *const libc::c_char,
+            c_flag.as_ptr() as *const libc::c_char,
+            cmd_cstr.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execv(sh.as_ptr() as *const i8, argv.as_ptr());
+            libc::execv(sh.as_ptr() as *const libc::c_char, argv.as_ptr());
             libc::_exit(127);
         }
     }

--- a/src/applets/network/ifup.rs
+++ b/src/applets/network/ifup.rs
@@ -523,10 +523,10 @@ fn configure_interface_direct(iface: &[u8], up: bool, verbose: bool) -> i32 {
     result
 }
 
-fn copy_iface_name(dest: &mut [i8; 16], src: &[u8]) {
+fn copy_iface_name(dest: &mut [libc::c_char; 16], src: &[u8]) {
     let len = src.len().min(15);
     for i in 0..len {
-        dest[i] = src[i] as i8;
+        dest[i] = src[i] as libc::c_char;
     }
     dest[len] = 0;
 }
@@ -635,15 +635,15 @@ fn run_command(cmd: &[u8]) -> i32 {
         let sh = b"/bin/sh\0";
         let c_flag = b"-c\0";
 
-        let argv: [*const i8; 4] = [
-            sh.as_ptr() as *const i8,
-            c_flag.as_ptr() as *const i8,
-            cmd_cstr.as_ptr() as *const i8,
+        let argv: [*const libc::c_char; 4] = [
+            sh.as_ptr() as *const libc::c_char,
+            c_flag.as_ptr() as *const libc::c_char,
+            cmd_cstr.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execv(sh.as_ptr() as *const i8, argv.as_ptr());
+            libc::execv(sh.as_ptr() as *const libc::c_char, argv.as_ptr());
             libc::_exit(127);
         }
     }

--- a/src/applets/network/nameif.rs
+++ b/src/applets/network/nameif.rs
@@ -136,7 +136,7 @@ fn rename_interface_by_mac(new_name: &[u8], target_mac: &[u8], _use_syslog: bool
 
     // Put new name in ifr_ifru.ifru_newname
     // This is a union, we need to access it correctly
-    let new_name_ptr = unsafe { &mut ifr.ifr_ifru.ifru_newname as *mut [i8; 16] };
+    let new_name_ptr = unsafe { &mut ifr.ifr_ifru.ifru_newname as *mut [libc::c_char; 16] };
     copy_iface_name(unsafe { &mut *new_name_ptr }, new_name);
 
     // SIOCSIFNAME = 0x8923
@@ -286,10 +286,10 @@ fn parse_mac(s: &[u8]) -> Option<[u8; 6]> {
     Some(mac)
 }
 
-fn copy_iface_name(dest: &mut [i8; 16], src: &[u8]) {
+fn copy_iface_name(dest: &mut [libc::c_char; 16], src: &[u8]) {
     let len = src.len().min(15);
     for i in 0..len {
-        dest[i] = src[i] as i8;
+        dest[i] = src[i] as libc::c_char;
     }
     dest[len] = 0;
 }

--- a/src/applets/network/nbd_client.rs
+++ b/src/applets/network/nbd_client.rs
@@ -263,7 +263,7 @@ pub fn nbd_client(argc: i32, argv: *const *const u8) -> i32 {
         // Child - daemonize
         unsafe {
             libc::setsid();
-            libc::chdir(b"/\0".as_ptr() as *const i8);
+            libc::chdir(b"/\0".as_ptr() as *const libc::c_char);
         }
     }
 
@@ -312,7 +312,7 @@ fn connect_to_server(host: &[u8], port: u16) -> i32 {
     hints.ai_socktype = libc::SOCK_STREAM;
 
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
-    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const i8, core::ptr::null(), &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_cstr.as_ptr() as *const libc::c_char, core::ptr::null(), &hints, &mut res) } != 0 {
         return -1;
     }
 

--- a/src/applets/network/nbd_server.rs
+++ b/src/applets/network/nbd_server.rs
@@ -215,7 +215,7 @@ pub fn nbd_server(argc: i32, argv: *const *const u8) -> i32 {
         // Child daemonizes
         unsafe {
             libc::setsid();
-            libc::chdir(b"/\0".as_ptr() as *const i8);
+            libc::chdir(b"/\0".as_ptr() as *const libc::c_char);
         }
     }
 

--- a/src/applets/network/nc.rs
+++ b/src/applets/network/nc.rs
@@ -38,7 +38,7 @@ pub fn nc(argc: i32, argv: *const *const u8) -> i32 {
     hints.ai_socktype = libc::SOCK_STREAM;
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
 
-    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const i8, port_buf.as_ptr() as *const i8, &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const libc::c_char, port_buf.as_ptr() as *const libc::c_char, &hints, &mut res) } != 0 {
         io::write_str(2, b"nc: cannot resolve host\n");
         return 1;
     }

--- a/src/applets/network/netstat.rs
+++ b/src/applets/network/netstat.rs
@@ -532,8 +532,8 @@ fn find_process_by_inode(inode: u64) -> Option<(u64, String)> {
                     link_path.push(0);
                     let n = unsafe {
                         libc::readlink(
-                            link_path.as_ptr() as *const i8,
-                            link_buf.as_mut_ptr() as *mut i8,
+                            link_path.as_ptr() as *const libc::c_char,
+                            link_buf.as_mut_ptr() as *mut libc::c_char,
                             link_buf.len()
                         )
                     };

--- a/src/applets/network/ping.rs
+++ b/src/applets/network/ping.rs
@@ -61,7 +61,7 @@ pub fn ping(argc: i32, argv: *const *const u8) -> i32 {
     hints.ai_family = libc::AF_INET;
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
 
-    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const i8, core::ptr::null(), &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const libc::c_char, core::ptr::null(), &hints, &mut res) } != 0 {
         io::write_str(2, b"ping: unknown host\n");
         unsafe { libc::close(sock) };
         return 1;

--- a/src/applets/network/route.rs
+++ b/src/applets/network/route.rs
@@ -404,7 +404,7 @@ fn add_route(args: &[&[u8]]) -> i32 {
         let mut dev_buf = [0u8; 16];
         let len = core::cmp::min(dev.len(), 15);
         dev_buf[..len].copy_from_slice(&dev[..len]);
-        rt.rt_dev = dev_buf.as_ptr() as *mut i8;
+        rt.rt_dev = dev_buf.as_ptr() as *mut libc::c_char;
     }
 
     // Open socket for ioctl

--- a/src/applets/network/sntp.rs
+++ b/src/applets/network/sntp.rs
@@ -198,7 +198,7 @@ pub fn sntp(argc: i32, argv: *const *const u8) -> i32 {
 
     // Format time
     let mut tm: libc::tm = unsafe { core::mem::zeroed() };
-    let time_t = unix_sec as i64;
+    let time_t = unix_sec as libc::time_t;
     unsafe { libc::gmtime_r(&time_t, &mut tm) };
 
     let mut buf = [0u8; 16];
@@ -222,7 +222,7 @@ pub fn sntp(argc: i32, argv: *const *const u8) -> i32 {
     // Set system time if requested
     if set_time {
         let new_tv = libc::timeval {
-            tv_sec: unix_sec as i64,
+            tv_sec: unix_sec as libc::time_t,
             tv_usec: unix_usec as libc::suseconds_t,
         };
 

--- a/src/applets/network/traceroute.rs
+++ b/src/applets/network/traceroute.rs
@@ -127,7 +127,7 @@ pub fn traceroute(argc: i32, argv: *const *const u8) -> i32 {
 
     // Set receive timeout
     let tv = libc::timeval {
-        tv_sec: wait_time as i64,
+        tv_sec: wait_time as libc::time_t,
         tv_usec: 0,
     };
     unsafe {

--- a/src/applets/network/wget.rs
+++ b/src/applets/network/wget.rs
@@ -60,7 +60,7 @@ pub fn wget(argc: i32, argv: *const *const u8) -> i32 {
     hints.ai_socktype = libc::SOCK_STREAM;
     let mut res: *mut libc::addrinfo = core::ptr::null_mut();
 
-    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const i8, port_buf.as_ptr() as *const i8, &hints, &mut res) } != 0 {
+    if unsafe { libc::getaddrinfo(host_buf.as_ptr() as *const libc::c_char, port_buf.as_ptr() as *const libc::c_char, &hints, &mut res) } != 0 {
         io::write_str(2, b"wget: cannot resolve host\n");
         return 1;
     }

--- a/src/applets/process/chrt.rs
+++ b/src/applets/process/chrt.rs
@@ -134,8 +134,8 @@ pub fn chrt(argc: i32, argv: *const *const u8) -> i32 {
 
         unsafe {
             libc::execvp(
-                cmd_buf.as_ptr() as *const i8,
-                argv.add(idx as usize) as *const *const i8,
+                cmd_buf.as_ptr() as *const libc::c_char,
+                argv.add(idx as usize) as *const *const libc::c_char,
             );
         }
         sys::perror(cmd);

--- a/src/applets/process/ionice.rs
+++ b/src/applets/process/ionice.rs
@@ -140,7 +140,7 @@ pub fn ionice(argc: i32, argv: *const *const u8) -> i32 {
         cmd_buf[..cmd.len()].copy_from_slice(cmd);
 
         unsafe {
-            libc::execvp(cmd_buf.as_ptr() as *const i8, argv.add(cmd_idx as usize) as *const *const i8);
+            libc::execvp(cmd_buf.as_ptr() as *const libc::c_char, argv.add(cmd_idx as usize) as *const *const libc::c_char);
         }
         sys::perror(cmd);
         io::exit(127);

--- a/src/applets/process/iorenice.rs
+++ b/src/applets/process/iorenice.rs
@@ -55,7 +55,7 @@ pub fn iorenice(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 3 {
         // Just show current priority
         let ioprio = unsafe {
-            libc::syscall(SYS_IOPRIO_GET, IOPRIO_WHO_PROCESS, pid)
+            libc::syscall(SYS_IOPRIO_GET as libc::c_long, IOPRIO_WHO_PROCESS, pid)
         } as i32;
 
         if ioprio < 0 {
@@ -109,7 +109,7 @@ pub fn iorenice(argc: i32, argv: *const *const u8) -> i32 {
     let ioprio = (class << 13) | (priority & 0x7);
 
     let result = unsafe {
-        libc::syscall(SYS_IOPRIO_SET, IOPRIO_WHO_PROCESS, pid, ioprio)
+        libc::syscall(SYS_IOPRIO_SET as libc::c_long, IOPRIO_WHO_PROCESS, pid, ioprio)
     };
 
     if result < 0 {

--- a/src/applets/process/nice.rs
+++ b/src/applets/process/nice.rs
@@ -62,8 +62,8 @@ pub fn nice(argc: i32, argv: *const *const u8) -> i32 {
 
     unsafe {
         libc::execvp(
-            cmd_buf.as_ptr() as *const i8,
-            argv.add(cmd_start as usize) as *const *const i8,
+            cmd_buf.as_ptr() as *const libc::c_char,
+            argv.add(cmd_start as usize) as *const *const libc::c_char,
         );
     }
 

--- a/src/applets/process/nohup.rs
+++ b/src/applets/process/nohup.rs
@@ -48,8 +48,8 @@ pub fn nohup(argc: i32, argv: *const *const u8) -> i32 {
 
     unsafe {
         libc::execvp(
-            cmd_buf.as_ptr() as *const i8,
-            argv.add(1) as *const *const i8,
+            cmd_buf.as_ptr() as *const libc::c_char,
+            argv.add(1) as *const *const libc::c_char,
         );
     }
 

--- a/src/applets/process/nsenter.rs
+++ b/src/applets/process/nsenter.rs
@@ -136,8 +136,8 @@ pub fn nsenter(argc: i32, argv: *const *const u8) -> i32 {
 
     unsafe {
         libc::execvp(
-            cmd_buf.as_ptr() as *const i8,
-            argv.add(cmd_idx as usize) as *const *const i8,
+            cmd_buf.as_ptr() as *const libc::c_char,
+            argv.add(cmd_idx as usize) as *const *const libc::c_char,
         );
     }
     sys::perror(cmd);

--- a/src/applets/process/pwdx.rs
+++ b/src/applets/process/pwdx.rs
@@ -29,7 +29,7 @@ pub fn pwdx(argc: i32, argv: *const *const u8) -> i32 {
     for &c in b"/cwd\0" { path[pi] = c; pi += 1; }
 
     let mut link_buf = [0u8; 4096];
-    let n = unsafe { libc::readlink(path.as_ptr() as *const i8, link_buf.as_mut_ptr() as *mut i8, link_buf.len() - 1) };
+    let n = unsafe { libc::readlink(path.as_ptr() as *const libc::c_char, link_buf.as_mut_ptr() as *mut libc::c_char, link_buf.len() - 1) };
     if n > 0 {
         io::write_all(1, pid);
         io::write_str(1, b": ");

--- a/src/applets/process/renice.rs
+++ b/src/applets/process/renice.rs
@@ -137,7 +137,7 @@ fn lookup_uid(name: &[u8]) -> Option<u32> {
     buf[..len].copy_from_slice(&name[..len]);
     buf[len] = 0;
 
-    let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const i8) };
+    let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const libc::c_char) };
     if pw.is_null() {
         None
     } else {

--- a/src/applets/process/setsid.rs
+++ b/src/applets/process/setsid.rs
@@ -34,7 +34,7 @@ pub fn setsid(argc: i32, argv: *const *const u8) -> i32 {
     let cmd = unsafe { get_arg(argv, 1).unwrap() };
     let mut cmd_buf = [0u8; 4096];
     cmd_buf[..cmd.len()].copy_from_slice(cmd);
-    let cmd_ptr = cmd_buf.as_ptr() as *const i8;
+    let cmd_ptr = cmd_buf.as_ptr() as *const libc::c_char;
     let argv_ptrs = [cmd_ptr, core::ptr::null()];
     unsafe { libc::execv(cmd_ptr, argv_ptrs.as_ptr()) };
     sys::perror(b"exec");

--- a/src/applets/process/timeout.rs
+++ b/src/applets/process/timeout.rs
@@ -34,7 +34,7 @@ pub fn timeout(argc: i32, argv: *const *const u8) -> i32 {
         // Child: execute command
         let mut cmd_buf = [0u8; 4096];
         cmd_buf[..cmd.len()].copy_from_slice(cmd);
-        let cmd_ptr = cmd_buf.as_ptr() as *const i8;
+        let cmd_ptr = cmd_buf.as_ptr() as *const libc::c_char;
         let argv_ptrs = [cmd_ptr, core::ptr::null()];
         unsafe { libc::execv(cmd_ptr, argv_ptrs.as_ptr()) };
         io::exit(127);

--- a/src/applets/process/uclampset.rs
+++ b/src/applets/process/uclampset.rs
@@ -190,7 +190,7 @@ pub fn uclampset(argc: i32, argv: *const *const u8) -> i32 {
 
         // Execute command
         unsafe {
-            libc::execvp(cmd_args[0] as *const i8, cmd_args.as_ptr() as *const *const i8);
+            libc::execvp(cmd_args[0] as *const libc::c_char, cmd_args.as_ptr() as *const *const libc::c_char);
         }
 
         sys::perror(b"exec");

--- a/src/applets/process/unshare.rs
+++ b/src/applets/process/unshare.rs
@@ -87,8 +87,8 @@ pub fn unshare(argc: i32, argv: *const *const u8) -> i32 {
 
     unsafe {
         libc::execvp(
-            cmd_buf.as_ptr() as *const i8,
-            argv.add(cmd_idx as usize) as *const *const i8,
+            cmd_buf.as_ptr() as *const libc::c_char,
+            argv.add(cmd_idx as usize) as *const *const libc::c_char,
         );
     }
     sys::perror(cmd);

--- a/src/applets/shell/builtins.rs
+++ b/src/applets/shell/builtins.rs
@@ -77,7 +77,7 @@ pub(super) fn execute_builtin(shell: &mut Shell, cmd: &Command) -> bool {
     if name == b"pwd" {
         let mut buf = [0u8; 4096];
         unsafe {
-            if !libc::getcwd(buf.as_mut_ptr() as *mut i8, buf.len()).is_null() {
+            if !libc::getcwd(buf.as_mut_ptr() as *mut libc::c_char, buf.len()).is_null() {
                 let len = io::strlen(buf.as_ptr());
                 io::write_all(1, &buf[..len]);
                 io::write_str(1, b"\n");

--- a/src/applets/shell/entry.rs
+++ b/src/applets/shell/entry.rs
@@ -217,7 +217,7 @@ pub(super) fn minimal_shell() {
             let plen = core::cmp::min(path.len(), path_buf.len() - 1);
             path_buf[..plen].copy_from_slice(&path[..plen]);
             unsafe {
-                if libc::chdir(path_buf.as_ptr() as *const i8) != 0 {
+                if libc::chdir(path_buf.as_ptr() as *const libc::c_char) != 0 {
                     io::write_str(2, b"cd: failed\n");
                 }
             }
@@ -227,7 +227,7 @@ pub(super) fn minimal_shell() {
         // Fork and exec
         let pid = io::fork();
         if pid == 0 {
-            let mut args: [*const i8; 32] = [core::ptr::null(); 32];
+            let mut args: [*const libc::c_char; 32] = [core::ptr::null(); 32];
             let mut arg_count = 0;
             let mut start = 0;
             let mut in_word = false;
@@ -236,7 +236,7 @@ pub(super) fn minimal_shell() {
                 if i == pos || line_buf[i] == b' ' || line_buf[i] == b'\t' {
                     if in_word && arg_count < 31 {
                         line_buf[i] = 0;
-                        args[arg_count] = line_buf[start..].as_ptr() as *const i8;
+                        args[arg_count] = line_buf[start..].as_ptr() as *const libc::c_char;
                         arg_count += 1;
                         in_word = false;
                     }

--- a/src/applets/shell/execute.rs
+++ b/src/applets/shell/execute.rs
@@ -487,8 +487,8 @@ pub(super) fn execute_simple_pipeline(shell: &mut Shell, tokens: &[Token]) {
                 value_buf[..vlen].copy_from_slice(&v[..vlen]);
                 unsafe {
                     libc::setenv(
-                        name_buf.as_ptr() as *const i8,
-                        value_buf.as_ptr() as *const i8,
+                        name_buf.as_ptr() as *const libc::c_char,
+                        value_buf.as_ptr() as *const libc::c_char,
                         1,
                     );
                 }
@@ -528,7 +528,7 @@ pub(super) fn execute_command(cmd: &Command) {
         return;
     }
 
-    let mut argv_ptrs: Vec<*const i8> = Vec::new();
+    let mut argv_ptrs: Vec<*const libc::c_char> = Vec::new();
     let mut argv_storage: Vec<Vec<u8>> = Vec::new();
 
     for arg in &cmd.args {
@@ -538,7 +538,7 @@ pub(super) fn execute_command(cmd: &Command) {
     }
 
     for s in &argv_storage {
-        argv_ptrs.push(s.as_ptr() as *const i8);
+        argv_ptrs.push(s.as_ptr() as *const libc::c_char);
     }
     argv_ptrs.push(core::ptr::null());
 

--- a/src/applets/shell/util.rs
+++ b/src/applets/shell/util.rs
@@ -163,7 +163,7 @@ pub(super) fn is_regular_file(path: &[u8]) -> bool {
     if io::stat(path, &mut stat_buf) != 0 {
         return false;
     }
-    (stat_buf.st_mode & libc::S_IFMT) == libc::S_IFREG
+    (stat_buf.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFREG as u32
 }
 
 /// Check if path is a directory
@@ -173,7 +173,7 @@ pub(super) fn is_directory(path: &[u8]) -> bool {
     if io::stat(path, &mut stat_buf) != 0 {
         return false;
     }
-    (stat_buf.st_mode & libc::S_IFMT) == libc::S_IFDIR
+    (stat_buf.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32
 }
 
 /// Check if path is readable
@@ -201,7 +201,7 @@ pub(super) fn is_symlink(path: &[u8]) -> bool {
     if io::lstat(path, &mut stat_buf) != 0 {
         return false;
     }
-    (stat_buf.st_mode & libc::S_IFMT) == libc::S_IFLNK
+    (stat_buf.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFLNK as u32
 }
 
 /// Get file size in bytes

--- a/src/applets/system/blkid.rs
+++ b/src/applets/system/blkid.rs
@@ -112,7 +112,7 @@ fn scan_all_devices(format: OutputFormat, show_tag: Option<&[u8]>) -> i32 {
     let mut found_any = false;
 
     // Read /sys/block to find block devices
-    let dir_fd = unsafe { libc::open(b"/sys/block\0".as_ptr() as *const i8, libc::O_RDONLY | libc::O_DIRECTORY) };
+    let dir_fd = unsafe { libc::open(b"/sys/block\0".as_ptr() as *const libc::c_char, libc::O_RDONLY | libc::O_DIRECTORY) };
     if dir_fd < 0 {
         return 2;
     }
@@ -176,7 +176,7 @@ fn scan_block_device(name: &[u8], format: OutputFormat, show_tag: Option<&[u8]>,
     sys_path.extend_from_slice(name);
     sys_path.push(0);
 
-    let dir_fd = unsafe { libc::open(sys_path.as_ptr() as *const i8, libc::O_RDONLY | libc::O_DIRECTORY) };
+    let dir_fd = unsafe { libc::open(sys_path.as_ptr() as *const libc::c_char, libc::O_RDONLY | libc::O_DIRECTORY) };
     if dir_fd < 0 {
         return;
     }
@@ -225,7 +225,7 @@ fn probe_device(path: &[u8]) -> Option<FsInfo> {
     path_z.extend_from_slice(path);
     path_z.push(0);
 
-    let fd = unsafe { libc::open(path_z.as_ptr() as *const i8, libc::O_RDONLY) };
+    let fd = unsafe { libc::open(path_z.as_ptr() as *const libc::c_char, libc::O_RDONLY) };
     if fd < 0 {
         return None;
     }

--- a/src/applets/system/chroot.rs
+++ b/src/applets/system/chroot.rs
@@ -29,11 +29,11 @@ pub fn chroot(argc: i32, argv: *const *const u8) -> i32 {
     let mut root_buf = [0u8; 4096];
     root_buf[..newroot.len()].copy_from_slice(newroot);
 
-    if unsafe { libc::chroot(root_buf.as_ptr() as *const i8) } != 0 {
+    if unsafe { libc::chroot(root_buf.as_ptr() as *const libc::c_char) } != 0 {
         sys::perror(b"chroot");
         return 1;
     }
-    if unsafe { libc::chdir(b"/\0".as_ptr() as *const i8) } != 0 {
+    if unsafe { libc::chdir(b"/\0".as_ptr() as *const libc::c_char) } != 0 {
         sys::perror(b"chdir");
         return 1;
     }
@@ -43,7 +43,7 @@ pub fn chroot(argc: i32, argv: *const *const u8) -> i32 {
         let cmd = unsafe { get_arg(argv, 2).unwrap() };
         let mut cmd_buf = [0u8; 4096];
         cmd_buf[..cmd.len()].copy_from_slice(cmd);
-        let cmd_ptr = cmd_buf.as_ptr() as *const i8;
+        let cmd_ptr = cmd_buf.as_ptr() as *const libc::c_char;
         let argv_ptrs = [cmd_ptr, core::ptr::null()];
         unsafe { libc::execv(cmd_ptr, argv_ptrs.as_ptr()) };
         sys::perror(b"exec");
@@ -52,8 +52,8 @@ pub fn chroot(argc: i32, argv: *const *const u8) -> i32 {
 
     // Default: run /bin/sh
     let shell = b"/bin/sh\0";
-    let argv_ptrs = [shell.as_ptr() as *const i8, core::ptr::null()];
-    unsafe { libc::execv(shell.as_ptr() as *const i8, argv_ptrs.as_ptr()) };
+    let argv_ptrs = [shell.as_ptr() as *const libc::c_char, core::ptr::null()];
+    unsafe { libc::execv(shell.as_ptr() as *const libc::c_char, argv_ptrs.as_ptr()) };
     sys::perror(b"exec");
     1
 }

--- a/src/applets/system/df.rs
+++ b/src/applets/system/df.rs
@@ -179,7 +179,7 @@ fn show_mount_entry(device: &[u8], mountpoint: &[u8], fstype: &[u8], human: bool
 
     // Get filesystem stats
     let mut stat_buf: StatFs = unsafe { core::mem::zeroed() };
-    let ret = unsafe { statfs(path_buf.as_ptr() as *const i8, &mut stat_buf) };
+    let ret = unsafe { statfs(path_buf.as_ptr() as *const libc::c_char, &mut stat_buf) };
 
     if ret < 0 {
         return;
@@ -279,7 +279,7 @@ fn show_filesystem(path: &[u8], human: bool, si: bool, inodes: bool, show_type: 
 
     // Get filesystem stats
     let mut stat_buf: StatFs = unsafe { core::mem::zeroed() };
-    let ret = unsafe { statfs(path_buf.as_ptr() as *const i8, &mut stat_buf) };
+    let ret = unsafe { statfs(path_buf.as_ptr() as *const libc::c_char, &mut stat_buf) };
 
     if ret < 0 {
         io::write_str(2, b"df: ");

--- a/src/applets/system/dmesg.rs
+++ b/src/applets/system/dmesg.rs
@@ -244,7 +244,7 @@ fn format_relative_time(timestamp_us: u64) {
 /// Format human-readable time
 fn format_human_time(timestamp: i64) {
     let mut tm: libc::tm = unsafe { core::mem::zeroed() };
-    let time_t = timestamp as i64;
+    let time_t = timestamp as libc::time_t;
     unsafe { libc::localtime_r(&time_t, &mut tm) };
 
     // Format: [Mon Jan  2 15:04:05 2006]

--- a/src/applets/system/dnsdomainname.rs
+++ b/src/applets/system/dnsdomainname.rs
@@ -19,7 +19,7 @@ use crate::io;
 pub fn dnsdomainname(_argc: i32, _argv: *const *const u8) -> i32 {
     let mut buf = [0u8; 256];
 
-    if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) } != 0 {
+    if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } != 0 {
         return 1;
     }
 

--- a/src/applets/system/du.rs
+++ b/src/applets/system/du.rs
@@ -38,13 +38,13 @@ pub fn du(argc: i32, argv: *const *const u8) -> i32 {
         path_buf[path.len()] = 0;
 
         let mut st: libc::stat = unsafe { core::mem::zeroed() };
-        if unsafe { libc::lstat(path_buf.as_ptr() as *const i8, &mut st) } != 0 {
+        if unsafe { libc::lstat(path_buf.as_ptr() as *const libc::c_char, &mut st) } != 0 {
             return 0;
         }
 
         total += (st.st_blocks * 512) / 1024; // Convert to KB
 
-        if (st.st_mode & libc::S_IFMT) == libc::S_IFDIR {
+        if (st.st_mode as u32 & libc::S_IFMT as u32) == libc::S_IFDIR as u32 {
             let fd = io::open(path, libc::O_RDONLY | libc::O_DIRECTORY, 0);
             if fd >= 0 {
                 let mut buf = [0u8; 4096];

--- a/src/applets/system/env.rs
+++ b/src/applets/system/env.rs
@@ -20,7 +20,7 @@ use crate::io;
 /// - >0: An error occurred
 pub fn env(argc: i32, argv: *const *const u8) -> i32 {
     unsafe extern "C" {
-        static environ: *const *const i8;
+        static environ: *const *const libc::c_char;
     }
 
     // NUL-terminate a byte slice for the C environment functions.
@@ -50,7 +50,7 @@ pub fn env(argc: i32, argv: *const *const u8) -> i32 {
             i += 1;
             if let Some(name) = unsafe { super::get_arg(argv, i) } {
                 let c = cstr(name);
-                unsafe { libc::unsetenv(c.as_ptr() as *const i8) };
+                unsafe { libc::unsetenv(c.as_ptr() as *const libc::c_char) };
                 i += 1;
             } else {
                 io::write_str(2, b"env: option requires an argument -- 'u'\n");
@@ -59,7 +59,7 @@ pub fn env(argc: i32, argv: *const *const u8) -> i32 {
         } else if arg.len() > 2 && arg[0] == b'-' && arg[1] == b'u' {
             // -uNAME form.
             let c = cstr(&arg[2..]);
-            unsafe { libc::unsetenv(c.as_ptr() as *const i8) };
+            unsafe { libc::unsetenv(c.as_ptr() as *const libc::c_char) };
             i += 1;
         } else {
             break;
@@ -77,7 +77,7 @@ pub fn env(argc: i32, argv: *const *const u8) -> i32 {
         if let Some(eq) = arg.iter().position(|&b| b == b'=') {
             let name = cstr(&arg[..eq]);
             let value = cstr(&arg[eq + 1..]);
-            unsafe { libc::setenv(name.as_ptr() as *const i8, value.as_ptr() as *const i8, 1) };
+            unsafe { libc::setenv(name.as_ptr() as *const libc::c_char, value.as_ptr() as *const libc::c_char, 1) };
             i += 1;
         } else {
             break;
@@ -89,7 +89,7 @@ pub fn env(argc: i32, argv: *const *const u8) -> i32 {
         // Exec the utility with the remaining argv (already NUL-terminated by
         // the OS) in the (possibly modified) environment.
         let file = unsafe { *argv.add(i as usize) };
-        unsafe { libc::execvp(file as *const i8, argv.add(i as usize) as *const *const i8) };
+        unsafe { libc::execvp(file as *const libc::c_char, argv.add(i as usize) as *const *const libc::c_char) };
         // execvp only returns on failure.
         let err = crate::sys::errno();
         let name = unsafe { super::get_arg(argv, i) }.unwrap_or(b"");

--- a/src/applets/system/flock.rs
+++ b/src/applets/system/flock.rs
@@ -48,7 +48,7 @@ pub fn flock(argc: i32, argv: *const *const u8) -> i32 {
     // Execute command
     let mut cmd_buf = [0u8; 4096];
     cmd_buf[..cmd.len()].copy_from_slice(cmd);
-    let cmd_ptr = cmd_buf.as_ptr() as *const i8;
+    let cmd_ptr = cmd_buf.as_ptr() as *const libc::c_char;
     let argv_ptrs = [cmd_ptr, core::ptr::null()];
     unsafe { libc::execv(cmd_ptr, argv_ptrs.as_ptr()) };
     io::close(fd);

--- a/src/applets/system/gpiodetect.rs
+++ b/src/applets/system/gpiodetect.rs
@@ -40,7 +40,7 @@ pub fn gpiodetect(_argc: i32, _argv: *const *const u8) -> i32 {
 
         // Check if device exists
         let mut stat_buf: libc::stat = unsafe { core::mem::zeroed() };
-        if unsafe { libc::stat(path.as_ptr() as *const i8, &mut stat_buf) } == 0 {
+        if unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat_buf) } == 0 {
             io::write_str(1, b"gpiochip");
             io::write_num(1, i as u64);
             io::write_str(1, b" [");

--- a/src/applets/system/gpioget.rs
+++ b/src/applets/system/gpioget.rs
@@ -148,7 +148,7 @@ pub fn gpioget(argc: i32, argv: *const *const u8) -> i32 {
     path.push(0);
 
     // Open GPIO chip
-    let fd = unsafe { libc::open(path.as_ptr() as *const i8, libc::O_RDONLY) };
+    let fd = unsafe { libc::open(path.as_ptr() as *const libc::c_char, libc::O_RDONLY) };
     if fd < 0 {
         io::write_str(2, b"gpioget: cannot open ");
         io::write_all(2, &path[..path.len()-1]);
@@ -252,7 +252,7 @@ fn read_gpio_sysfs(chip: &[u8], lines: &[u32], active_low: bool) -> i32 {
         // Export GPIO if needed
         let mut export_path = b"/sys/class/gpio/export".to_vec();
         export_path.push(0);
-        let export_fd = unsafe { libc::open(export_path.as_ptr() as *const i8, libc::O_WRONLY) };
+        let export_fd = unsafe { libc::open(export_path.as_ptr() as *const libc::c_char, libc::O_WRONLY) };
         if export_fd >= 0 {
             let gpio_str = sys::format_u64(gpio_num as u64, &mut num_buf);
             unsafe {

--- a/src/applets/system/gpioinfo.rs
+++ b/src/applets/system/gpioinfo.rs
@@ -112,7 +112,7 @@ fn show_chip_info(chip_num: u8) -> bool {
     path.push(0);
 
     // Open the device
-    let fd = unsafe { libc::open(path.as_ptr() as *const i8, libc::O_RDONLY) };
+    let fd = unsafe { libc::open(path.as_ptr() as *const libc::c_char, libc::O_RDONLY) };
     if fd < 0 {
         return false;
     }

--- a/src/applets/system/hostname.rs
+++ b/src/applets/system/hostname.rs
@@ -52,7 +52,7 @@ pub fn hostname(argc: i32, argv: *const *const u8) -> i32 {
             // Trim trailing whitespace/newlines
             let name = content.trim_ascii();
             if !name.is_empty() {
-                if unsafe { libc::sethostname(name.as_ptr() as *const i8, name.len()) } < 0 {
+                if unsafe { libc::sethostname(name.as_ptr() as *const libc::c_char, name.len()) } < 0 {
                     sys::perror(b"sethostname");
                     return 1;
                 }
@@ -61,7 +61,7 @@ pub fn hostname(argc: i32, argv: *const *const u8) -> i32 {
         } else if arg == b"-s" || arg == b"--short" {
             // Print short hostname (up to first dot)
             let mut buf = [0u8; 256];
-            if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) } == 0 {
+            if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } == 0 {
                 let full = unsafe { io::cstr_to_slice(buf.as_ptr()) };
                 if let Some(dot) = full.iter().position(|&c| c == b'.') {
                     io::write_all(1, &full[..dot]);
@@ -74,7 +74,7 @@ pub fn hostname(argc: i32, argv: *const *const u8) -> i32 {
         } else if arg == b"-d" || arg == b"--domain" {
             // Print domain name
             let mut buf = [0u8; 256];
-            if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) } == 0 {
+            if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } == 0 {
                 let full = unsafe { io::cstr_to_slice(buf.as_ptr()) };
                 if let Some(dot) = full.iter().position(|&c| c == b'.') {
                     io::write_all(1, &full[dot + 1..]);
@@ -84,7 +84,7 @@ pub fn hostname(argc: i32, argv: *const *const u8) -> i32 {
             return 0;
         } else if arg[0] != b'-' {
             // Set hostname directly
-            if unsafe { libc::sethostname(arg.as_ptr() as *const i8, arg.len()) } < 0 {
+            if unsafe { libc::sethostname(arg.as_ptr() as *const libc::c_char, arg.len()) } < 0 {
                 sys::perror(b"sethostname");
                 return 1;
             }
@@ -96,7 +96,7 @@ pub fn hostname(argc: i32, argv: *const *const u8) -> i32 {
 
     // No arguments - print current hostname
     let mut buf = [0u8; 256];
-    if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) } == 0 {
+    if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } == 0 {
         io::write_all(1, unsafe { io::cstr_to_slice(buf.as_ptr()) });
         io::write_str(1, b"\n");
     }

--- a/src/applets/system/id.rs
+++ b/src/applets/system/id.rs
@@ -108,7 +108,7 @@ pub fn id(argc: i32, argv: *const *const u8) -> i32 {
         let mut buf = alloc::vec::Vec::with_capacity(u.len() + 1);
         buf.extend_from_slice(u);
         buf.push(0);
-        let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const i8) };
+        let pw = unsafe { libc::getpwnam(buf.as_ptr() as *const libc::c_char) };
         if pw.is_null() {
             io::write_str(2, b"id: '");
             io::write_all(2, u);
@@ -151,7 +151,7 @@ pub fn id(argc: i32, argv: *const *const u8) -> i32 {
         loop {
             let rc = unsafe {
                 libc::getgrouplist(
-                    buf.as_ptr() as *const i8,
+                    buf.as_ptr() as *const libc::c_char,
                     gid as libc::gid_t,
                     groups.as_mut_ptr(),
                     &mut ngroups,

--- a/src/applets/system/inotifyd.rs
+++ b/src/applets/system/inotifyd.rs
@@ -101,7 +101,7 @@ pub fn inotifyd(argc: i32, argv: *const *const u8) -> i32 {
             path[..len].copy_from_slice(&file[..len]);
 
             let wd = unsafe {
-                libc::inotify_add_watch(inotify_fd, path.as_ptr() as *const i8, mask)
+                libc::inotify_add_watch(inotify_fd, path.as_ptr() as *const libc::c_char, mask)
             };
             if wd < 0 {
                 sys::perror(file);
@@ -291,14 +291,14 @@ fn execute_handler(prog: &[u8], event_char: u8, path: &[u8]) {
         path_buf[..path_len].copy_from_slice(&path[..path_len]);
 
         let argv_ptrs = [
-            prog_buf.as_ptr() as *const i8,
-            event_buf.as_ptr() as *const i8,
-            path_buf.as_ptr() as *const i8,
+            prog_buf.as_ptr() as *const libc::c_char,
+            event_buf.as_ptr() as *const libc::c_char,
+            path_buf.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execvp(prog_buf.as_ptr() as *const i8, argv_ptrs.as_ptr());
+            libc::execvp(prog_buf.as_ptr() as *const libc::c_char, argv_ptrs.as_ptr());
             libc::_exit(127);
         }
     } else if pid > 0 {

--- a/src/applets/system/insmod.rs
+++ b/src/applets/system/insmod.rs
@@ -100,7 +100,7 @@ pub fn insmod(argc: i32, argv: *const *const u8) -> i32 {
     };
 
     if ret != 0 {
-        let errno = unsafe { *libc::__errno_location() };
+        let errno = crate::sys::errno();
         io::write_str(2, b"insmod: cannot insert '");
         io::write_all(2, path);
         io::write_str(2, b"': ");

--- a/src/applets/system/linux32.rs
+++ b/src/applets/system/linux32.rs
@@ -24,7 +24,7 @@ const PER_LINUX32: u64 = 0x0008;
 /// - Exit status of PROGRAM, or 1 on error
 pub fn linux32(argc: i32, argv: *const *const u8) -> i32 {
     // Set personality to 32-bit
-    let result = unsafe { libc::personality(PER_LINUX32) };
+    let result = unsafe { libc::personality(PER_LINUX32 as libc::c_ulong) };
     if result < 0 {
         sys::perror(b"personality");
         return 1;
@@ -35,7 +35,7 @@ pub fn linux32(argc: i32, argv: *const *const u8) -> i32 {
         let shell = b"/bin/sh\0";
         let args: [*const u8; 2] = [shell.as_ptr(), core::ptr::null()];
         unsafe {
-            libc::execv(shell.as_ptr() as *const i8, args.as_ptr() as *const *const i8);
+            libc::execv(shell.as_ptr() as *const libc::c_char, args.as_ptr() as *const *const libc::c_char);
         }
         sys::perror(b"/bin/sh");
         return 1;
@@ -52,8 +52,8 @@ pub fn linux32(argc: i32, argv: *const *const u8) -> i32 {
     // Execute the program
     unsafe {
         libc::execvp(
-            prog_buf.as_ptr() as *const i8,
-            argv.add(1) as *const *const i8,
+            prog_buf.as_ptr() as *const libc::c_char,
+            argv.add(1) as *const *const libc::c_char,
         );
     }
 

--- a/src/applets/system/logger.rs
+++ b/src/applets/system/logger.rs
@@ -282,7 +282,7 @@ fn log_message(priority: i32, tag: &[u8], pid: i32, message: &[u8], to_stderr: b
         addr.sun_family = libc::AF_UNIX as u16;
         // Copy path
         for (i, &b) in dev_log.iter().take(107).enumerate() {
-            addr.sun_path[i] = b as i8;
+            addr.sun_path[i] = b as libc::c_char;
         }
 
         let ret = unsafe {

--- a/src/applets/system/login.rs
+++ b/src/applets/system/login.rs
@@ -154,7 +154,7 @@ pub fn login(argc: i32, argv: *const *const u8) -> i32 {
 
     // Initialize supplementary groups
     let username_cstr = make_cstr(&username);
-    if unsafe { libc::initgroups(username_cstr.as_ptr() as *const i8, passwd_entry.gid) } < 0 {
+    if unsafe { libc::initgroups(username_cstr.as_ptr() as *const libc::c_char, passwd_entry.gid) } < 0 {
         sys::perror(b"initgroups");
         return 1;
     }
@@ -166,9 +166,9 @@ pub fn login(argc: i32, argv: *const *const u8) -> i32 {
 
     // Change to home directory
     let home_cstr = make_cstr(&passwd_entry.home);
-    if unsafe { libc::chdir(home_cstr.as_ptr() as *const i8) } < 0 {
+    if unsafe { libc::chdir(home_cstr.as_ptr() as *const libc::c_char) } < 0 {
         // Fall back to /
-        unsafe { libc::chdir(b"/\0".as_ptr() as *const i8) };
+        unsafe { libc::chdir(b"/\0".as_ptr() as *const libc::c_char) };
     }
 
     // Set up environment
@@ -211,13 +211,13 @@ pub fn login(argc: i32, argv: *const *const u8) -> i32 {
     }
     shell_name.push(0);
 
-    let argv: [*const i8; 2] = [
-        shell_name.as_ptr() as *const i8,
+    let argv: [*const libc::c_char; 2] = [
+        shell_name.as_ptr() as *const libc::c_char,
         core::ptr::null(),
     ];
 
     unsafe {
-        libc::execv(shell_cstr.as_ptr() as *const i8, argv.as_ptr());
+        libc::execv(shell_cstr.as_ptr() as *const libc::c_char, argv.as_ptr());
     }
 
     sys::perror(b"exec");
@@ -976,8 +976,8 @@ fn set_env(name: &[u8], value: &[u8]) {
     let value_cstr = make_cstr(value);
     unsafe {
         libc::setenv(
-            name_cstr.as_ptr() as *const i8,
-            value_cstr.as_ptr() as *const i8,
+            name_cstr.as_ptr() as *const libc::c_char,
+            value_cstr.as_ptr() as *const libc::c_char,
             1,
         );
     }
@@ -985,7 +985,7 @@ fn set_env(name: &[u8], value: &[u8]) {
 
 fn get_env(name: &[u8]) -> Result<Vec<u8>, ()> {
     let name_cstr = make_cstr(name);
-    let ptr = unsafe { libc::getenv(name_cstr.as_ptr() as *const i8) };
+    let ptr = unsafe { libc::getenv(name_cstr.as_ptr() as *const libc::c_char) };
     if ptr.is_null() {
         return Err(());
     }

--- a/src/applets/system/modinfo.rs
+++ b/src/applets/system/modinfo.rs
@@ -75,7 +75,7 @@ fn show_module_info(module: &[u8], field_filter: Option<&[u8]>) -> bool {
     // Check if module exists in /sys/module
     let mut stat_buf: libc::stat = unsafe { core::mem::zeroed() };
     path[pos] = 0; // Null terminate
-    if unsafe { libc::stat(path.as_ptr() as *const i8, &mut stat_buf) } != 0 {
+    if unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat_buf) } != 0 {
         io::write_str(2, b"modinfo: module ");
         io::write_all(2, module);
         io::write_str(2, b" not found\n");

--- a/src/applets/system/mount.rs
+++ b/src/applets/system/mount.rs
@@ -47,8 +47,8 @@ pub fn mount(argc: i32, argv: *const *const u8) -> i32 {
 
     let ret = unsafe {
         libc::mount(
-            source_buf.as_ptr() as *const i8,
-            target_buf.as_ptr() as *const i8,
+            source_buf.as_ptr() as *const libc::c_char,
+            target_buf.as_ptr() as *const libc::c_char,
             core::ptr::null(),
             0,
             core::ptr::null(),

--- a/src/applets/system/mountpoint.rs
+++ b/src/applets/system/mountpoint.rs
@@ -29,7 +29,7 @@ pub fn mountpoint(argc: i32, argv: *const *const u8) -> i32 {
     let mut st1: libc::stat = unsafe { core::mem::zeroed() };
     let mut st2: libc::stat = unsafe { core::mem::zeroed() };
 
-    if unsafe { libc::stat(path_buf.as_ptr() as *const i8, &mut st1) } != 0 {
+    if unsafe { libc::stat(path_buf.as_ptr() as *const libc::c_char, &mut st1) } != 0 {
         return 1;
     }
 
@@ -42,7 +42,7 @@ pub fn mountpoint(argc: i32, argv: *const *const u8) -> i32 {
     parent[plen] = b'.'; plen += 1;
     parent[plen] = 0;
 
-    if unsafe { libc::stat(parent.as_ptr() as *const i8, &mut st2) } != 0 {
+    if unsafe { libc::stat(parent.as_ptr() as *const libc::c_char, &mut st2) } != 0 {
         return 1;
     }
 

--- a/src/applets/system/openvt.rs
+++ b/src/applets/system/openvt.rs
@@ -133,8 +133,8 @@ pub fn openvt(argc: i32, argv: *const *const u8) -> i32 {
 
         unsafe {
             libc::execvp(
-                prog_buf.as_ptr() as *const i8,
-                argv.add(cmd_start as usize) as *const *const i8,
+                prog_buf.as_ptr() as *const libc::c_char,
+                argv.add(cmd_start as usize) as *const *const libc::c_char,
             );
         }
         sys::perror(prog);

--- a/src/applets/system/printenv.rs
+++ b/src/applets/system/printenv.rs
@@ -24,7 +24,7 @@ use super::env::env;
 pub fn printenv(argc: i32, argv: *const *const u8) -> i32 {
     if argc > 1 {
         if let Some(name) = unsafe { get_arg(argv, 1) } {
-            let val = unsafe { libc::getenv(name.as_ptr() as *const i8) };
+            let val = unsafe { libc::getenv(name.as_ptr() as *const libc::c_char) };
             if !val.is_null() {
                 io::write_all(1, unsafe { io::cstr_to_slice(val as *const u8) });
                 io::write_str(1, b"\n");

--- a/src/applets/system/rtcwake.rs
+++ b/src/applets/system/rtcwake.rs
@@ -50,7 +50,7 @@ pub fn rtcwake(argc: i32, argv: *const *const u8) -> i32 {
         // Show current RTC time
         let now = unsafe { libc::time(core::ptr::null_mut()) };
         io::write_str(1, b"Current RTC time: ");
-        io::write_signed(1, now);
+        io::write_signed(1, now as i64);
         io::write_str(1, b"\n");
         return 0;
     }
@@ -66,7 +66,7 @@ pub fn rtcwake(argc: i32, argv: *const *const u8) -> i32 {
     }
 
     // Calculate wake time
-    let wake_time = unsafe { libc::time(core::ptr::null_mut()) } + seconds;
+    let wake_time = unsafe { libc::time(core::ptr::null_mut()) } as i64 + seconds;
 
     io::write_str(1, b"rtcwake: wakeup scheduled for ");
     io::write_signed(1, wake_time);

--- a/src/applets/system/sleep.rs
+++ b/src/applets/system/sleep.rs
@@ -123,7 +123,7 @@ pub fn sleep(argc: i32, argv: *const *const u8) -> i32 {
 
     let mut req = libc::timespec {
         tv_sec: secs_whole,
-        tv_nsec: nanos,
+        tv_nsec: nanos as libc::c_long,
     };
 
     loop {
@@ -137,7 +137,7 @@ pub fn sleep(argc: i32, argv: *const *const u8) -> i32 {
             break;
         }
 
-        let errno = unsafe { *libc::__errno_location() };
+        let errno = crate::sys::errno();
         if errno == libc::EINTR {
             // Interrupted by a signal; resume sleeping for the remaining time.
             req = rem;

--- a/src/applets/system/su.rs
+++ b/src/applets/system/su.rs
@@ -127,7 +127,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
     let user_len = user.len().min(user_buf.len() - 1);
     user_buf[..user_len].copy_from_slice(&user[..user_len]);
     unsafe {
-        libc::initgroups(user_buf.as_ptr() as *const i8, user_info.gid as libc::gid_t);
+        libc::initgroups(user_buf.as_ptr() as *const libc::c_char, user_info.gid as libc::gid_t);
     }
 
     // Set user ID
@@ -143,7 +143,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         home_env.extend_from_slice(&user_info.home);
         home_env.push(0);
         unsafe {
-            libc::putenv(home_env.as_ptr() as *mut i8);
+            libc::putenv(home_env.as_ptr() as *mut libc::c_char);
         }
         core::mem::forget(home_env); // Don't free the env string
 
@@ -152,7 +152,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         shell_env.extend_from_slice(&shell);
         shell_env.push(0);
         unsafe {
-            libc::putenv(shell_env.as_ptr() as *mut i8);
+            libc::putenv(shell_env.as_ptr() as *mut libc::c_char);
         }
         core::mem::forget(shell_env);
 
@@ -161,7 +161,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         user_env.extend_from_slice(user);
         user_env.push(0);
         unsafe {
-            libc::putenv(user_env.as_ptr() as *mut i8);
+            libc::putenv(user_env.as_ptr() as *mut libc::c_char);
         }
         core::mem::forget(user_env);
 
@@ -170,7 +170,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         logname_env.extend_from_slice(user);
         logname_env.push(0);
         unsafe {
-            libc::putenv(logname_env.as_ptr() as *mut i8);
+            libc::putenv(logname_env.as_ptr() as *mut libc::c_char);
         }
         core::mem::forget(logname_env);
 
@@ -179,7 +179,7 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         let home_len = user_info.home.len().min(home_buf.len() - 1);
         home_buf[..home_len].copy_from_slice(&user_info.home[..home_len]);
         unsafe {
-            libc::chdir(home_buf.as_ptr() as *const i8);
+            libc::chdir(home_buf.as_ptr() as *const libc::c_char);
         }
     }
 
@@ -196,14 +196,14 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
 
         let c_flag = b"-c\0";
         let argv_ptrs = [
-            shell_buf.as_ptr() as *const i8,
-            c_flag.as_ptr() as *const i8,
-            cmd_buf.as_ptr() as *const i8,
+            shell_buf.as_ptr() as *const libc::c_char,
+            c_flag.as_ptr() as *const libc::c_char,
+            cmd_buf.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execv(shell_buf.as_ptr() as *const i8, argv_ptrs.as_ptr());
+            libc::execv(shell_buf.as_ptr() as *const libc::c_char, argv_ptrs.as_ptr());
         }
     } else {
         // Build shell name for argv[0] (with or without leading -)
@@ -224,12 +224,12 @@ pub fn su(argc: i32, argv: *const *const u8) -> i32 {
         shell_name[start..start + name_len].copy_from_slice(&shell_basename[..name_len]);
 
         let argv_ptrs = [
-            shell_name.as_ptr() as *const i8,
+            shell_name.as_ptr() as *const libc::c_char,
             core::ptr::null(),
         ];
 
         unsafe {
-            libc::execv(shell_buf.as_ptr() as *const i8, argv_ptrs.as_ptr());
+            libc::execv(shell_buf.as_ptr() as *const libc::c_char, argv_ptrs.as_ptr());
         }
     }
 

--- a/src/applets/system/swapoff.rs
+++ b/src/applets/system/swapoff.rs
@@ -24,7 +24,7 @@ pub fn swapoff(argc: i32, argv: *const *const u8) -> i32 {
     let mut path_buf = [0u8; 4096];
     path_buf[..path.len()].copy_from_slice(path);
 
-    if unsafe { libc::swapoff(path_buf.as_ptr() as *const i8) } != 0 {
+    if unsafe { libc::swapoff(path_buf.as_ptr() as *const libc::c_char) } != 0 {
         sys::perror(b"swapoff");
         return 1;
     }

--- a/src/applets/system/swapon.rs
+++ b/src/applets/system/swapon.rs
@@ -24,7 +24,7 @@ pub fn swapon(argc: i32, argv: *const *const u8) -> i32 {
     let mut path_buf = [0u8; 4096];
     path_buf[..path.len()].copy_from_slice(path);
 
-    if unsafe { libc::swapon(path_buf.as_ptr() as *const i8, 0) } != 0 {
+    if unsafe { libc::swapon(path_buf.as_ptr() as *const libc::c_char, 0) } != 0 {
         sys::perror(b"swapon");
         return 1;
     }

--- a/src/applets/system/sysctl.rs
+++ b/src/applets/system/sysctl.rs
@@ -24,7 +24,7 @@ pub fn sysctl(argc: i32, argv: *const *const u8) -> i32 {
         // List all sysctl values - just show a few common ones
         io::write_str(1, b"kernel.hostname = ");
         let mut buf = [0u8; 256];
-        if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) } == 0 {
+        if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } == 0 {
             io::write_all(1, unsafe { io::cstr_to_slice(buf.as_ptr()) });
         }
         io::write_str(1, b"\n");

--- a/src/applets/system/umount.rs
+++ b/src/applets/system/umount.rs
@@ -24,7 +24,7 @@ pub fn umount(argc: i32, argv: *const *const u8) -> i32 {
     let mut target_buf = [0u8; 4096];
     target_buf[..target.len()].copy_from_slice(target);
 
-    let ret = unsafe { libc::umount(target_buf.as_ptr() as *const i8) };
+    let ret = unsafe { libc::umount(target_buf.as_ptr() as *const libc::c_char) };
     if ret != 0 { sys::perror(b"umount"); 1 } else { 0 }
 }
 

--- a/src/applets/system/w.rs
+++ b/src/applets/system/w.rs
@@ -306,7 +306,7 @@ fn get_users_from_proc() -> Vec<UserSession> {
         name,
         tty,
         host: String::new(),
-        login_time: unsafe { libc::time(core::ptr::null_mut()) },
+        login_time: unsafe { libc::time(core::ptr::null_mut()) } as i64,
         pid: unsafe { libc::getpid() },
     });
 
@@ -353,8 +353,8 @@ fn get_current_tty() -> String {
     let mut link_buf = [0u8; 256];
     let n = unsafe {
         libc::readlink(
-            b"/proc/self/fd/0\0".as_ptr() as *const i8,
-            link_buf.as_mut_ptr() as *mut i8,
+            b"/proc/self/fd/0\0".as_ptr() as *const libc::c_char,
+            link_buf.as_mut_ptr() as *mut libc::c_char,
             link_buf.len()
         )
     };
@@ -527,7 +527,8 @@ fn print_user_long(user: &UserSession) {
 
     // LOGIN@ (8)
     let mut tm: libc::tm = unsafe { core::mem::zeroed() };
-    unsafe { libc::localtime_r(&user.login_time, &mut tm); }
+    let login_time = user.login_time as libc::time_t;
+    unsafe { libc::localtime_r(&login_time, &mut tm); }
     let h = sys::format_u64(tm.tm_hour as u64, &mut buf);
     if h.len() < 2 { io::write_str(1, b"0"); }
     io::write_all(1, h);

--- a/src/applets/system/watch.rs
+++ b/src/applets/system/watch.rs
@@ -57,12 +57,12 @@ pub fn watch(argc: i32, argv: *const *const u8) -> i32 {
             let shell = b"/bin/sh\0";
             let c_flag = b"-c\0";
             let argv_ptrs = [
-                shell.as_ptr() as *const i8,
-                c_flag.as_ptr() as *const i8,
-                cmd_buf.as_ptr() as *const i8,
+                shell.as_ptr() as *const libc::c_char,
+                c_flag.as_ptr() as *const libc::c_char,
+                cmd_buf.as_ptr() as *const libc::c_char,
                 core::ptr::null(),
             ];
-            unsafe { libc::execv(shell.as_ptr() as *const i8, argv_ptrs.as_ptr()) };
+            unsafe { libc::execv(shell.as_ptr() as *const libc::c_char, argv_ptrs.as_ptr()) };
             io::exit(1);
         }
 

--- a/src/applets/system/who.rs
+++ b/src/applets/system/who.rs
@@ -315,8 +315,8 @@ fn get_my_tty() -> Option<[u8; 32]> {
     // Get tty name from /proc/self/fd/0
     let n = unsafe {
         libc::readlink(
-            b"/proc/self/fd/0\0".as_ptr() as *const i8,
-            tty_buf.as_mut_ptr() as *mut i8,
+            b"/proc/self/fd/0\0".as_ptr() as *const libc::c_char,
+            tty_buf.as_mut_ptr() as *mut libc::c_char,
             tty_buf.len() - 1,
         )
     };
@@ -349,7 +349,7 @@ fn get_mesg_status(line: &[u8]) -> u8 {
     path[5..5 + len].copy_from_slice(&line[..len]);
 
     let mut stat: libc::stat = unsafe { core::mem::zeroed() };
-    let ret = unsafe { libc::stat(path.as_ptr() as *const i8, &mut stat) };
+    let ret = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) };
 
     if ret < 0 {
         return b'?';
@@ -370,7 +370,7 @@ fn get_idle_time(line: &[u8]) -> i64 {
     path[5..5 + len].copy_from_slice(&line[..len]);
 
     let mut stat: libc::stat = unsafe { core::mem::zeroed() };
-    let ret = unsafe { libc::stat(path.as_ptr() as *const i8, &mut stat) };
+    let ret = unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) };
 
     if ret < 0 {
         return -1;
@@ -379,14 +379,14 @@ fn get_idle_time(line: &[u8]) -> i64 {
     let mut now: libc::timespec = unsafe { core::mem::zeroed() };
     unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut now) };
 
-    now.tv_sec - stat.st_atime
+    now.tv_sec as i64 - stat.st_atime as i64
 }
 
 #[cfg(target_os = "linux")]
 fn format_time(timestamp: i64) {
     // Convert timestamp to broken-down time
     let tm = unsafe {
-        let t = timestamp as i64;
+        let t = timestamp as libc::time_t;
         libc::localtime(&t)
     };
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -171,7 +171,7 @@ pub fn open(path: &[u8], flags: i32, mode: u32) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::open(path_buf.as_ptr() as *const i8, flags, mode) }
+    unsafe { libc::open(path_buf.as_ptr() as *const libc::c_char, flags, mode) }
 }
 
 /// Close a file descriptor
@@ -200,7 +200,7 @@ pub fn stat(path: &[u8], buf: &mut libc::stat) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::stat(path_buf.as_ptr() as *const i8, buf) }
+    unsafe { libc::stat(path_buf.as_ptr() as *const libc::c_char, buf) }
 }
 
 /// Get file status (no follow symlinks)
@@ -212,7 +212,7 @@ pub fn lstat(path: &[u8], buf: &mut libc::stat) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::lstat(path_buf.as_ptr() as *const i8, buf) }
+    unsafe { libc::lstat(path_buf.as_ptr() as *const libc::c_char, buf) }
 }
 
 /// Get file status from fd
@@ -229,7 +229,7 @@ pub fn mkdir(path: &[u8], mode: u32) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::mkdir(path_buf.as_ptr() as *const i8, mode as libc::mode_t) }
+    unsafe { libc::mkdir(path_buf.as_ptr() as *const libc::c_char, mode as libc::mode_t) }
 }
 
 /// Remove a directory
@@ -241,7 +241,7 @@ pub fn rmdir(path: &[u8]) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::rmdir(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::rmdir(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Unlink (remove) a file
@@ -253,7 +253,7 @@ pub fn unlink(path: &[u8]) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::unlink(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::unlink(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Rename a file
@@ -270,7 +270,7 @@ pub fn rename(old: &[u8], new: &[u8]) -> i32 {
     new_buf[..new.len()].copy_from_slice(new);
     new_buf[new.len()] = 0;
 
-    unsafe { libc::rename(old_buf.as_ptr() as *const i8, new_buf.as_ptr() as *const i8) }
+    unsafe { libc::rename(old_buf.as_ptr() as *const libc::c_char, new_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Create a symlink
@@ -287,7 +287,7 @@ pub fn symlink(target: &[u8], linkpath: &[u8]) -> i32 {
     link_buf[..linkpath.len()].copy_from_slice(linkpath);
     link_buf[linkpath.len()] = 0;
 
-    unsafe { libc::symlink(target_buf.as_ptr() as *const i8, link_buf.as_ptr() as *const i8) }
+    unsafe { libc::symlink(target_buf.as_ptr() as *const libc::c_char, link_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Create a hard link
@@ -304,7 +304,7 @@ pub fn link(old: &[u8], new: &[u8]) -> i32 {
     new_buf[..new.len()].copy_from_slice(new);
     new_buf[new.len()] = 0;
 
-    unsafe { libc::link(old_buf.as_ptr() as *const i8, new_buf.as_ptr() as *const i8) }
+    unsafe { libc::link(old_buf.as_ptr() as *const libc::c_char, new_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Change file permissions
@@ -316,7 +316,7 @@ pub fn chmod(path: &[u8], mode: u32) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::chmod(path_buf.as_ptr() as *const i8, mode as libc::mode_t) }
+    unsafe { libc::chmod(path_buf.as_ptr() as *const libc::c_char, mode as libc::mode_t) }
 }
 
 /// Change working directory
@@ -328,14 +328,14 @@ pub fn chdir(path: &[u8]) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::chdir(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::chdir(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Get current working directory
 #[cfg(feature = "alloc")]
 pub fn getcwd() -> Option<Vec<u8>> {
     let mut buf = [0u8; 4096];
-    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut i8, buf.len()) };
+    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 
     if ret.is_null() {
         None
@@ -348,7 +348,7 @@ pub fn getcwd() -> Option<Vec<u8>> {
 /// Get current working directory (no alloc version)
 #[cfg(not(feature = "alloc"))]
 pub fn getcwd(buf: &mut [u8]) -> bool {
-    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut i8, buf.len()) };
+    let ret = unsafe { libc::getcwd(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
     !ret.is_null()
 }
 
@@ -359,7 +359,7 @@ pub fn readlink(path: &[u8], buf: &mut [u8]) -> isize {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::readlink(path_buf.as_ptr() as *const i8, buf.as_mut_ptr() as *mut i8, buf.len()) }
+    unsafe { libc::readlink(path_buf.as_ptr() as *const libc::c_char, buf.as_mut_ptr() as *mut libc::c_char, buf.len()) }
 }
 
 /// Get canonical path
@@ -369,7 +369,7 @@ pub fn realpath(path: &[u8], buf: &mut [u8]) -> isize {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    let ret = unsafe { libc::realpath(path_buf.as_ptr() as *const i8, buf.as_mut_ptr() as *mut i8) };
+    let ret = unsafe { libc::realpath(path_buf.as_ptr() as *const libc::c_char, buf.as_mut_ptr() as *mut libc::c_char) };
     if ret.is_null() {
         -1
     } else {
@@ -386,7 +386,7 @@ pub fn opendir(path: &[u8]) -> *mut libc::DIR {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::opendir(path_buf.as_ptr() as *const i8) }
+    unsafe { libc::opendir(path_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Read directory entry
@@ -430,7 +430,7 @@ pub fn access(path: &[u8], mode: i32) -> i32 {
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::access(path_buf.as_ptr() as *const i8, mode) }
+    unsafe { libc::access(path_buf.as_ptr() as *const libc::c_char, mode) }
 }
 
 /// Get process ID
@@ -447,7 +447,7 @@ pub fn getppid() -> i32 {
 #[cfg(feature = "alloc")]
 pub fn gethostname() -> Option<Vec<u8>> {
     let mut buf = [0u8; 256];
-    let ret = unsafe { libc::gethostname(buf.as_mut_ptr() as *mut i8, buf.len()) };
+    let ret = unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
 
     if ret != 0 {
         None
@@ -544,7 +544,7 @@ pub fn getenv(name: &[u8]) -> Option<&'static [u8]> {
 
     // SAFETY: libc::getenv returns a pointer to environment memory.
     // This memory is managed by libc and can be invalidated by setenv/unsetenv.
-    let ptr = unsafe { libc::getenv(name_buf.as_ptr() as *const i8) };
+    let ptr = unsafe { libc::getenv(name_buf.as_ptr() as *const libc::c_char) };
     if ptr.is_null() {
         None
     } else {
@@ -589,8 +589,8 @@ pub fn setenv(name: &[u8], value: &[u8], overwrite: bool) -> i32 {
     // The libc function copies the data, so our stack buffers can go out of scope.
     unsafe {
         libc::setenv(
-            name_buf.as_ptr() as *const i8,
-            value_buf.as_ptr() as *const i8,
+            name_buf.as_ptr() as *const libc::c_char,
+            value_buf.as_ptr() as *const libc::c_char,
             if overwrite { 1 } else { 0 },
         )
     }
@@ -617,7 +617,7 @@ pub fn unsetenv(name: &[u8]) -> i32 {
     name_buf[name.len()] = 0;
 
     // SAFETY: Buffer is properly null-terminated.
-    unsafe { libc::unsetenv(name_buf.as_ptr() as *const i8) }
+    unsafe { libc::unsetenv(name_buf.as_ptr() as *const libc::c_char) }
 }
 
 /// Send signal to process
@@ -627,7 +627,7 @@ pub fn kill(pid: i32, sig: i32) -> i32 {
 
 /// Execute program
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn execve(path: &[u8], argv: *const *const i8, envp: *const *const i8) -> i32 {
+pub fn execve(path: &[u8], argv: *const *const libc::c_char, envp: *const *const libc::c_char) -> i32 {
     let mut path_buf = [0u8; 4096];
     if path.len() >= path_buf.len() {
         return -1;
@@ -635,7 +635,7 @@ pub fn execve(path: &[u8], argv: *const *const i8, envp: *const *const i8) -> i3
     path_buf[..path.len()].copy_from_slice(path);
     path_buf[path.len()] = 0;
 
-    unsafe { libc::execve(path_buf.as_ptr() as *const i8, argv, envp) }
+    unsafe { libc::execve(path_buf.as_ptr() as *const libc::c_char, argv, envp) }
 }
 
 /// Fork process

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,8 @@ fn install_symlinks(dir: &[u8]) -> i32 {
 
     let n = unsafe {
         libc::readlink(
-            target_buf.as_ptr() as *const i8,
-            target.as_mut_ptr() as *mut i8,
+            target_buf.as_ptr() as *const libc::c_char,
+            target.as_mut_ptr() as *mut libc::c_char,
             target.len() - 1
         )
     };

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -240,7 +240,11 @@ pub fn makedev(major: u32, minor: u32) -> libc::dev_t {
 
 /// Get errno - works on glibc, musl, and Bionic
 pub fn errno() -> i32 {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    // Bionic exposes errno as `__errno()`; glibc and musl as `__errno_location()`.
+    #[cfg(target_os = "android")]
+    unsafe { *libc::__errno() }
+
+    #[cfg(target_os = "linux")]
     unsafe { *libc::__errno_location() }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -249,7 +253,10 @@ pub fn errno() -> i32 {
 
 /// Clear errno
 pub fn clear_errno() {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "android")]
+    unsafe { *libc::__errno() = 0; }
+
+    #[cfg(target_os = "linux")]
     unsafe { *libc::__errno_location() = 0; }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]


### PR DESCRIPTION
## Summary

Fixes cross-compilation for Android (Bionic) and 32-bit ARM targets, prompted by a user report that `crates/abp` fails to build with cargo-ndk (16 type errors), plus follow-up issues surfaced by code review.

- **c_char portability**: Bionic's `libc::c_char` is `u8`, not `i8`. Replaced all hardcoded `*const i8`/`*mut i8` casts and type annotations with `libc::c_char` throughout `src/` and `crates/abp` (argv/envp arrays, `sun_path`, `ifr_name`).
- **mode_t width**: `st_mode & S_IFMT` comparisons now use width-safe `as u32` casts; new `io::is_dir()`/`io::is_reg()` helpers in abp replace the duplicated cast chains.
- **32-bit time_t/c_long**: 13 applets assumed 64-bit `time_t` (touch, w, who, sleep, dmesg, rtcwake, linux32, iorenice, getconf, ts, traceroute, arping, sntp); they now cast through `libc::time_t`/`c_long`.
- **Android errno**: Bionic exposes errno as `__errno()`, not `__errno_location()`. Fixed `sys::errno()`/`clear_errno()`, added shared `io::errno()`/`set_errno()` in abp, and routed five applets' raw errno reads through `sys::errno()`.
- **Stale-errno bug**: abp's io path helpers now set `ENAMETOOLONG` on the too-long-path short circuit, so `mkdir_tracked()` can no longer misread a stale `EEXIST` as success for a directory that was never created.

## Verification

- `cargo check --release` clean (0 errors) on `aarch64-unknown-linux-musl` and `armv7-unknown-linux-musleabihf` (the release-matrix targets, previously 173 errors)
- `cargo check -p abp` clean on `aarch64-linux-android` and `armv7-linux-androideabi`
- Host release build green; 1468 tests pass, 0 failed (release profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)