### PR TITLE
feat: full applet parity on Android; aarch64-linux-android release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
             os: ubuntu-latest
             cross: true
 
+          # Android ARM64 (Bionic)
+          - target: aarch64-linux-android
+            os: ubuntu-latest
+            cross: true
+
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/superpowers/specs/2026-08-18-android-bionic-support-design.md
+++ b/docs/superpowers/specs/2026-08-18-android-bionic-support-design.md
@@ -1,0 +1,125 @@
+# Android/Bionic Support for the Full armybox Binary
+
+**Date:** 2026-08-18
+**Status:** Approved
+**Goal:** Full applet parity on Android with `aarch64-linux-android` as a release target.
+
+## Background
+
+Commit `ad53b10e` (PR #5) fixed `c_char`, `mode_t`, `time_t`, and errno portability,
+which made `crates/abp` build cleanly for Android and fixed the musl ARM release
+targets. The full armybox binary still fails on `aarch64-linux-android` with 59
+errors in two categories:
+
+1. **17 missing-symbol errors** — the libc crate does not export these for
+   Android: `reboot`/`RB_*` (halt, poweroff, reboot applets), `struct rtentry`
+   and `RTF_*` (route), `SCHED_OTHER` (chrt), `gethostid` (hostid),
+   `_PC_FILESIZEBITS` (getconf). Some exist in Bionic but are unbound in the
+   libc crate; `gethostid` is genuinely absent from Bionic.
+2. **~42 mismatched-type errors** — one root cause: Bionic's `ioctl()` takes
+   `c_int` as the request argument where glibc/musl take `c_ulong`. Affects
+   blockdev, blkdiscard, chvt, deallocvt, eject, freeramdisk, fsfreeze, gpio*,
+   i2c*, openvt, partprobe, screen, init, route, and `personality()` in linux32.
+
+## Decisions
+
+- **Approach:** local compat layer (Approach A). No waiting on upstream libc
+  releases; upstreaming bindings later is an optional cleanup, not a dependency.
+- **Targets:** `aarch64-linux-android` only in the release matrix. Other ABIs
+  build locally with cargo-ndk if needed.
+- **Applets:** no applet is gated out on Android. Full parity.
+
+## Design
+
+### 1. Compat layer in `src/sys.rs`
+
+All additions follow the cfg-split pattern `sys::errno()` already uses.
+
+- `pub type IoctlReq` — `libc::c_int` on `target_os = "android"`,
+  `libc::c_ulong` otherwise. Fixes the ~42 ioctl errors via call-site casts.
+- `pub fn reboot(cmd: i32) -> i32` — calls `libc::reboot(cmd)` off-Android; on
+  Android issues `libc::syscall(SYS_reboot, LINUX_REBOOT_MAGIC1,
+  LINUX_REBOOT_MAGIC2, cmd, 0)`. `RB_AUTOBOOT` (0x01234567),
+  `RB_HALT_SYSTEM` (0xcdef0123), and `RB_POWER_OFF` (0x4321fedc) are defined
+  under cfg for Android — kernel ABI values from `linux/reboot.h`, identical on
+  every Linux.
+- `pub fn gethostid() -> i64` — calls `libc::gethostid()` off-Android; on
+  Android (no gethostid in Bionic) uses busybox semantics: read `/etc/hostid`
+  if present, else return 0.
+- constants `SCHED_OTHER`, `_PC_FILESIZEBITS`, `RB_AUTOBOOT`,
+  `RB_HALT_SYSTEM`, `RB_POWER_OFF`: `sys.rs` re-exports the libc crate's
+  values off-Android (`pub use libc::...`) and defines them under
+  `#[cfg(target_os = "android")]` otherwise, so applets reference `sys::` on
+  every platform. Bionic has `SCHED_OTHER` and `_PC_FILESIZEBITS`; the libc
+  crate just does not bind them for Android. Values are taken from the NDK
+  headers (`sched.h`, `bits/posix_limits.h`/`unistd.h`) and verified during
+  implementation, not assumed.
+
+Applets `halt`, `poweroff`, `reboot`, `hostid`, `chrt`, and `getconf` switch
+from the missing `libc::` items to the `sys::` equivalents on all platforms
+(one code path; the cfg lives in `sys.rs`).
+
+### 2. `rtentry` in `src/applets/network/route.rs`
+
+`struct rtentry`, `RTF_UP` (0x0001), `RTF_GATEWAY` (0x0002), and `RTF_HOST`
+(0x0004) are kernel ABI from `linux/route.h`, identical on every Linux. Under
+`#[cfg(target_os = "android")]`, define a `#[repr(C)]` `rtentry` and the three
+constants locally in `route.rs`; under `#[cfg(not(target_os = "android"))]`,
+`use libc::rtentry`. They stay in `route.rs` because it is the only consumer.
+The struct layout must match libc's `rtentry` field-for-field so both cfg arms
+share the same construction code.
+
+### 3. Applet ioctl sweep
+
+Mechanical pass over the affected files: `libc::ioctl(fd, REQ, ...)` becomes
+`libc::ioctl(fd, REQ as sys::IoctlReq, ...)`. On non-Android targets the cast
+is `c_ulong as c_ulong` — a no-op — so host behavior is unchanged by
+construction. Individually handled:
+
+- `personality(PER_LINUX32)` in `linux32.rs`: cast to the platform's parameter
+  type (Bionic's signature differs from glibc/musl here too).
+- Any ioctl request constants the libc crate turns out not to bind on Android
+  get local cfg-gated definitions next to their use. These are discovered by
+  iterating `cargo check --target aarch64-linux-android` until clean, since the
+  current 59 errors stop at the first failing layer.
+
+### 4. Release matrix
+
+Add to `.github/workflows/release.yml`:
+
+```yaml
+- target: aarch64-linux-android
+  os: ubuntu-latest
+  cross: true
+```
+
+cross-rs ships an NDK-based image for this target, so it slots in exactly like
+the musl ARM entries — both the `armybox` binary and `abpd-gen` build steps
+apply unchanged. No cargo-ndk plumbing in CI.
+
+## Error handling
+
+- `sys::reboot` and `sys::gethostid` preserve the current call-site contracts:
+  return `-1`/errno on failure like the libc functions they replace, so applet
+  error paths need no changes.
+- The `/etc/hostid` fallback treats an unreadable or short file as absent
+  (return 0) rather than erroring — matching busybox.
+
+## Testing and verification
+
+- Gate: `cargo check --release --target aarch64-linux-android
+  --no-default-features --features "abp,alloc,full"` at 0 errors.
+- Regression: host `cargo build --release` and the full release-profile test
+  suite (currently 1468 passing) stay green. The sweep is behaviorally inert
+  off-Android, so existing tests cover it.
+- Existing targets: `aarch64-unknown-linux-musl` and
+  `armv7-unknown-linux-musleabihf` release checks stay at 0 errors.
+- Runtime smoke test (`adb push` + run on a device or emulator) stays manual;
+  CI has no emulator.
+
+## Out of scope
+
+- Other Android ABIs in CI (arm32, x86_64, x86).
+- Upstreaming the missing bindings to rust-lang/libc (optional follow-up).
+- SELinux/permission behavior of applets at runtime on Android; this design is
+  about building, and runtime capability is bounded by the device's policy.

--- a/src/applets/file/attrs.rs
+++ b/src/applets/file/attrs.rs
@@ -28,7 +28,7 @@ const FS_IOC_SETFLAGS: crate::io::IoctlReq = 0x40086602u32 as crate::io::IoctlRe
 ///
 /// Usage: chattr [-R] [-v version] [-p project] mode files...
 /// Mode: [+-=][aAcCdDeijsStTu]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn chattr(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         io::write_str(2, b"Usage: chattr [-R] [-v version] [mode] files...\n");
@@ -150,7 +150,7 @@ pub fn chattr(argc: i32, argv: *const *const u8) -> i32 {
     status
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn chattr(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"chattr: only available on Linux\n");
     1
@@ -159,7 +159,7 @@ pub fn chattr(_argc: i32, _argv: *const *const u8) -> i32 {
 /// lsattr - list file attributes on a Linux file system
 ///
 /// Usage: lsattr [-R] [-a] [-d] [-l] [-v] files...
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn lsattr(argc: i32, argv: *const *const u8) -> i32 {
     let mut show_all = false;
     let mut dir_only = false;
@@ -211,7 +211,7 @@ pub fn lsattr(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn list_attrs(path: &[u8], long_format: bool) {
     let fd = io::open(path, libc::O_RDONLY, 0);
     if fd < 0 {
@@ -289,7 +289,7 @@ fn list_attrs(path: &[u8], long_format: bool) {
     io::write_str(1, b"\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn lsattr(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"lsattr: only available on Linux\n");
     1
@@ -623,7 +623,7 @@ fn process_device_table(table_path: &[u8], rootdir: &[u8]) -> i32 {
 /// setfattr - set extended attributes of filesystem objects
 ///
 /// Usage: setfattr [-n name] [-v value] [-x name] file...
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn setfattr(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         io::write_str(2, b"Usage: setfattr [-n name] [-v value] [-x name] file...\n");
@@ -719,7 +719,7 @@ pub fn setfattr(argc: i32, argv: *const *const u8) -> i32 {
     status
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn setfattr(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"setfattr: only available on Linux\n");
     1

--- a/src/applets/misc/getconf.rs
+++ b/src/applets/misc/getconf.rs
@@ -62,7 +62,7 @@ fn pathconf_var(name: &[u8]) -> Option<libc::c_int> {
         b"MAX_CANON" => libc::_PC_MAX_CANON,
         b"MAX_INPUT" => libc::_PC_MAX_INPUT,
         b"PIPE_BUF" => libc::_PC_PIPE_BUF,
-        b"FILESIZEBITS" => libc::_PC_FILESIZEBITS,
+        b"FILESIZEBITS" => crate::sys::_PC_FILESIZEBITS,
         b"_POSIX_CHOWN_RESTRICTED" => libc::_PC_CHOWN_RESTRICTED,
         b"_POSIX_NO_TRUNC" => libc::_PC_NO_TRUNC,
         _ => return None,

--- a/src/applets/misc/mix.rs
+++ b/src/applets/misc/mix.rs
@@ -20,7 +20,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Cannot open mixer or set volume
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn mix(argc: i32, argv: *const *const u8) -> i32 {
     const SOUND_MIXER_READ_VOLUME: crate::io::IoctlReq = 0x80044D00u32 as crate::io::IoctlReq;
     const SOUND_MIXER_WRITE_VOLUME: crate::io::IoctlReq = 0xC0044D00u32 as crate::io::IoctlReq;
@@ -99,7 +99,7 @@ pub fn mix(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn mix(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"mix: only available on Linux\n");
     1

--- a/src/applets/network/arping.rs
+++ b/src/applets/network/arping.rs
@@ -33,7 +33,7 @@ const IP_ALEN: usize = 4;
 /// # Exit Status
 /// - 0: At least one reply received
 /// - 1: No reply received or error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn arping(argc: i32, argv: *const *const u8) -> i32 {
     let mut count: Option<u32> = None;
     let mut interface: &[u8] = b"eth0";
@@ -287,14 +287,14 @@ pub fn arping(argc: i32, argv: *const *const u8) -> i32 {
     if received > 0 { 0 } else { 1 }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn arping(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"arping: only available on Linux\n");
     1
 }
 
 /// Get interface MAC address, IP address, and index
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_interface_info(name: &[u8]) -> Option<([u8; 6], u32, i32)> {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     if sock < 0 {
@@ -347,7 +347,7 @@ fn get_interface_info(name: &[u8]) -> Option<([u8; 6], u32, i32)> {
     Some((mac, ip, if_index))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn parse_ipv4(s: &[u8]) -> Option<u32> {
     let mut parts = [0u8; 4];
     let mut part_idx = 0;
@@ -385,7 +385,7 @@ fn parse_ipv4(s: &[u8]) -> Option<u32> {
          (parts[3] as u32))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_ip(ip: u32) {
     let mut buf = [0u8; 16];
     io::write_all(1, sys::format_u64(((ip >> 24) & 0xFF) as u64, &mut buf));
@@ -397,7 +397,7 @@ fn print_ip(ip: u32) {
     io::write_all(1, sys::format_u64((ip & 0xFF) as u64, &mut buf));
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_mac(mac: &[u8]) {
     let mut buf = [0u8; 8];
     for (i, &b) in mac.iter().enumerate() {

--- a/src/applets/network/brctl.rs
+++ b/src/applets/network/brctl.rs
@@ -8,17 +8,17 @@ use crate::sys;
 use super::get_arg;
 
 // Bridge ioctl commands
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCBRADDBR: crate::io::IoctlReq = 0x89a0u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCBRDELBR: crate::io::IoctlReq = 0x89a1u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCBRADDIF: crate::io::IoctlReq = 0x89a2u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCBRDELIF: crate::io::IoctlReq = 0x89a3u32 as crate::io::IoctlReq;
 
 // Network interface ioctl
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCGIFINDEX: crate::io::IoctlReq = 0x8933u32 as crate::io::IoctlReq;
 
 /// brctl - ethernet bridge administration
@@ -46,7 +46,7 @@ const SIOCGIFINDEX: crate::io::IoctlReq = 0x8933u32 as crate::io::IoctlReq;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn brctl(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         print_usage();
@@ -158,13 +158,13 @@ pub fn brctl(argc: i32, argv: *const *const u8) -> i32 {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn brctl(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"brctl: only available on Linux\n");
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn addbr(bridge: &[u8]) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -191,7 +191,7 @@ fn addbr(bridge: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn delbr(bridge: &[u8]) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -217,7 +217,7 @@ fn delbr(bridge: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn addif(bridge: &[u8], iface: &[u8]) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -261,7 +261,7 @@ fn addif(bridge: &[u8], iface: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn delif(bridge: &[u8], iface: &[u8]) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -303,7 +303,7 @@ fn delif(bridge: &[u8], iface: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show(bridge: Option<&[u8]>) -> i32 {
     io::write_str(1, b"bridge name\tbridge id\t\tSTP enabled\tinterfaces\n");
 
@@ -357,7 +357,7 @@ fn show(bridge: Option<&[u8]>) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct LinuxDirent64 {
     d_ino: u64,
@@ -367,7 +367,7 @@ struct LinuxDirent64 {
     // d_name follows
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn is_bridge(name: &[u8]) -> bool {
     let mut path = Vec::new();
     path.extend_from_slice(b"/sys/class/net/");
@@ -379,7 +379,7 @@ fn is_bridge(name: &[u8]) -> bool {
     unsafe { libc::stat(path.as_ptr() as *const libc::c_char, &mut stat) == 0 }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show_bridge_info(name: &[u8]) {
     io::write_all(1, name);
     io::write_str(1, b"\t\t");
@@ -473,7 +473,7 @@ fn show_bridge_info(name: &[u8]) {
     io::write_str(1, b"\n");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn stp(bridge: &[u8], state: &[u8]) -> i32 {
     let value = if state == b"on" || state == b"yes" || state == b"1" {
         b"1"
@@ -503,7 +503,7 @@ fn stp(bridge: &[u8], state: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_bridge_param(bridge: &[u8], param: &[u8], value: u64) -> i32 {
     let sysfs_name = if param == b"setfd" {
         b"forward_delay" as &[u8]
@@ -544,7 +544,7 @@ fn set_bridge_param(bridge: &[u8], param: &[u8], value: u64) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_if_index(sock: i32, iface: &[u8]) -> Option<libc::c_int> {
     let mut ifr: libc::ifreq = unsafe { core::mem::zeroed() };
     let len = core::cmp::min(iface.len(), libc::IFNAMSIZ - 1);
@@ -560,7 +560,7 @@ fn get_if_index(sock: i32, iface: &[u8]) -> Option<libc::c_int> {
     Some(unsafe { ifr.ifr_ifru.ifru_ifindex })
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_errno() {
     let errno = crate::sys::errno();
     let msg = match errno {

--- a/src/applets/network/ether_wake.rs
+++ b/src/applets/network/ether_wake.rs
@@ -24,7 +24,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn ether_wake(argc: i32, argv: *const *const u8) -> i32 {
     let mut interface: Option<&[u8]> = None;
     let mut mac: Option<[u8; 6]> = None;
@@ -158,14 +158,14 @@ pub fn ether_wake(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn ether_wake(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"ether-wake: only available on Linux\n");
     1
 }
 
 /// Parse MAC address in AA:BB:CC:DD:EE:FF or AA-BB-CC-DD-EE-FF format
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn parse_mac(s: &[u8]) -> Option<[u8; 6]> {
     let mut mac = [0u8; 6];
     let mut idx = 0;
@@ -208,7 +208,7 @@ fn parse_mac(s: &[u8]) -> Option<[u8; 6]> {
     Some(mac)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_mac(mac: &[u8; 6]) {
     let mut buf = [0u8; 3];
     for (i, &b) in mac.iter().enumerate() {
@@ -220,7 +220,7 @@ fn print_mac(mac: &[u8; 6]) {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn format_hex_byte(val: u8, buf: &mut [u8; 3]) -> &[u8] {
     const HEX: &[u8] = b"0123456789abcdef";
     buf[0] = HEX[(val >> 4) as usize];

--- a/src/applets/network/httpd.rs
+++ b/src/applets/network/httpd.rs
@@ -34,7 +34,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn httpd(argc: i32, argv: *const *const u8) -> i32 {
     let mut foreground = false;
     let mut port: u16 = 80;
@@ -198,7 +198,7 @@ pub fn httpd(argc: i32, argv: *const *const u8) -> i32 {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn handle_request(fd: i32, _verbose: bool) {
     let mut buf = [0u8; 4096];
     let n = io::read(fd, &mut buf);
@@ -322,7 +322,7 @@ fn handle_request(fd: i32, _verbose: bool) {
     io::close(file_fd);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn send_error(fd: i32, code: u32, message: &[u8]) {
     let mut buf = [0u8; 16];
 
@@ -469,7 +469,7 @@ fn print_usage() {
     io::write_str(1, b"  -v        Verbose mode\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn httpd(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"httpd: only available on Linux\n");
     1

--- a/src/applets/network/ifdown.rs
+++ b/src/applets/network/ifdown.rs
@@ -25,7 +25,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn ifdown(argc: i32, argv: *const *const u8) -> i32 {
     let mut all = false;
     let mut force = false;
@@ -211,7 +211,7 @@ fn join(parts: &[&[u8]], sep: &[u8]) -> Vec<u8> {
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn deconfigure_interface(config: &InterfaceConfig, _force: bool, verbose: bool) -> i32 {
     // Run pre-down commands
     for cmd in &config.pre_down {
@@ -249,7 +249,7 @@ fn deconfigure_interface(config: &InterfaceConfig, _force: bool, verbose: bool) 
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn deconfigure_interface_direct(iface: &[u8], verbose: bool) -> i32 {
     if verbose {
         io::write_str(1, b"  Bringing interface down\n");
@@ -333,7 +333,7 @@ fn print_usage() {
     io::write_str(1, b"  -v        Verbose output\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn ifdown(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"ifdown: only available on Linux\n");
     1

--- a/src/applets/network/ifup.rs
+++ b/src/applets/network/ifup.rs
@@ -28,7 +28,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn ifup(argc: i32, argv: *const *const u8) -> i32 {
     let mut all = false;
     let mut force = false;
@@ -250,7 +250,7 @@ fn join(parts: &[&[u8]], sep: &[u8]) -> Vec<u8> {
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn configure_interface(config: &InterfaceConfig, _force: bool, verbose: bool) -> i32 {
     // Run pre-up commands
     for cmd in &config.pre_up {
@@ -303,7 +303,7 @@ fn configure_interface(config: &InterfaceConfig, _force: bool, verbose: bool) ->
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn configure_loopback(iface: &[u8], verbose: bool) -> i32 {
     if verbose {
         io::write_str(1, b"  Configuring loopback\n");
@@ -361,7 +361,7 @@ fn configure_loopback(iface: &[u8], verbose: bool) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn configure_dhcp(iface: &[u8], verbose: bool) -> i32 {
     if verbose {
         io::write_str(1, b"  Running DHCP client\n");
@@ -389,7 +389,7 @@ fn configure_dhcp(iface: &[u8], verbose: bool) -> i32 {
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn configure_static(config: &InterfaceConfig, verbose: bool) -> i32 {
     let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     if fd < 0 {
@@ -486,7 +486,7 @@ fn configure_static(config: &InterfaceConfig, verbose: bool) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn configure_interface_direct(iface: &[u8], up: bool, verbose: bool) -> i32 {
     if verbose {
         io::write_str(1, b"  Bringing interface ");
@@ -572,7 +572,7 @@ fn parse_ipv4(s: &[u8]) -> Option<u32> {
     Some(u32::from_ne_bytes(octets))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn add_default_route(gateway: &[u8]) -> i32 {
     let gw_ip = match parse_ipv4(gateway) {
         Some(ip) => ip,
@@ -584,7 +584,7 @@ fn add_default_route(gateway: &[u8]) -> i32 {
         return 1;
     }
 
-    let mut rt: libc::rtentry = unsafe { core::mem::zeroed() };
+    let mut rt: crate::sys::rtentry = unsafe { core::mem::zeroed() };
 
     // Destination: 0.0.0.0
     let dst = create_sockaddr_in(0);
@@ -610,7 +610,7 @@ fn add_default_route(gateway: &[u8]) -> i32 {
                                         core::mem::size_of::<libc::sockaddr_in>());
     }
 
-    rt.rt_flags = libc::RTF_UP as u16 | libc::RTF_GATEWAY as u16;
+    rt.rt_flags = crate::sys::RTF_UP as u16 | crate::sys::RTF_GATEWAY as u16;
 
     let result = unsafe { libc::ioctl(fd, libc::SIOCADDRT as _, &rt) };
     io::close(fd);
@@ -664,7 +664,7 @@ fn print_usage() {
     io::write_str(1, b"  -v        Verbose output\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn ifup(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"ifup: only available on Linux\n");
     1

--- a/src/applets/network/microcom.rs
+++ b/src/applets/network/microcom.rs
@@ -26,7 +26,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn microcom(argc: i32, argv: *const *const u8) -> i32 {
     let mut speed: u32 = 115200;
     let mut device: Option<&[u8]> = None;
@@ -244,7 +244,7 @@ pub fn microcom(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn microcom(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"microcom: only available on Linux\n");
     1

--- a/src/applets/network/nameif.rs
+++ b/src/applets/network/nameif.rs
@@ -25,7 +25,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn nameif(argc: i32, argv: *const *const u8) -> i32 {
     let mut config_file: &[u8] = b"/etc/mactab";
     let mut use_syslog = false;
@@ -97,7 +97,7 @@ pub fn nameif(argc: i32, argv: *const *const u8) -> i32 {
     exit_code
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn rename_interface_by_mac(new_name: &[u8], target_mac: &[u8], _use_syslog: bool) -> i32 {
     // Parse target MAC address
     let target = match parse_mac(target_mac) {
@@ -157,7 +157,7 @@ fn rename_interface_by_mac(new_name: &[u8], target_mac: &[u8], _use_syslog: bool
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn find_interface_by_mac(target: &[u8; 6]) -> Option<Vec<u8>> {
     // Read /sys/class/net to find all interfaces
     let dir_fd = io::open(b"/sys/class/net", libc::O_RDONLY | libc::O_DIRECTORY, 0);
@@ -314,7 +314,7 @@ fn print_usage() {
     io::write_str(1, b"  -c FILE   Use FILE instead of /etc/mactab\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn nameif(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"nameif: only available on Linux\n");
     1

--- a/src/applets/network/nbd_client.rs
+++ b/src/applets/network/nbd_client.rs
@@ -86,7 +86,7 @@ const NBD_FLAG_C_NO_ZEROES: u32 = 1 << 1;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn nbd_client(argc: i32, argv: *const *const u8) -> i32 {
     let mut host: Option<&[u8]> = None;
     let mut port: u16 = 10809;
@@ -279,7 +279,7 @@ pub fn nbd_client(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn connect_to_server(host: &[u8], port: u16) -> i32 {
     // Try parsing as IP first
     if let Some(ip) = parse_ipv4(host) {
@@ -379,7 +379,7 @@ fn parse_ipv4(s: &[u8]) -> Option<u32> {
     Some(u32::from_ne_bytes(octets))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn nbd_handshake(fd: i32, export_name: &[u8]) -> Option<(u64, u16)> {
     let mut buf = [0u8; 256];
 
@@ -423,7 +423,7 @@ fn nbd_handshake(fd: i32, export_name: &[u8]) -> Option<(u64, u16)> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn newstyle_handshake(fd: i32, export_name: &[u8]) -> Option<(u64, u16)> {
     let mut buf = [0u8; 1024];
 
@@ -485,7 +485,7 @@ fn newstyle_handshake(fd: i32, export_name: &[u8]) -> Option<(u64, u16)> {
     Some((size, flags))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn try_opt_go(fd: i32, export_name: &[u8]) -> Option<(u64, u16)> {
     let mut buf = [0u8; 1024];
 
@@ -587,7 +587,7 @@ fn read_exact(fd: i32, buf: &mut [u8]) -> isize {
     total as isize
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn disconnect_device(device: &[u8]) -> i32 {
     let fd = io::open(device, libc::O_RDWR, 0);
     if fd < 0 {
@@ -618,7 +618,7 @@ fn print_usage() {
     io::write_str(1, b"  -p          Persist (don't daemonize)\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn nbd_client(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"nbd-client: only available on Linux\n");
     1

--- a/src/applets/network/nbd_server.rs
+++ b/src/applets/network/nbd_server.rs
@@ -81,7 +81,7 @@ const NBD_ENOSPC: u32 = 28;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn nbd_server(argc: i32, argv: *const *const u8) -> i32 {
     let mut port: u16 = 10809;
     let mut file: Option<&[u8]> = None;
@@ -268,7 +268,7 @@ pub fn nbd_server(argc: i32, argv: *const *const u8) -> i32 {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn handle_client(fd: i32, file: &[u8], size: u64, read_only: bool, _copy_on_write: bool, _export_name: &[u8], _debug: bool) -> i32 {
     // Send newstyle handshake
     // Magic (8 bytes) + opts magic (8 bytes) + handshake flags (2 bytes)
@@ -537,7 +537,7 @@ fn print_usage() {
     io::write_str(1, b"  -n NAME   Export name\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn nbd_server(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"nbd-server: only available on Linux\n");
     1

--- a/src/applets/network/route.rs
+++ b/src/applets/network/route.rs
@@ -9,6 +9,8 @@ use crate::io;
 use crate::sys;
 use crate::applets::get_arg;
 
+use crate::sys::{rtentry, RTF_GATEWAY, RTF_HOST, RTF_UP};
+
 /// route - show/manipulate IP routing table
 ///
 /// # Synopsis
@@ -361,7 +363,7 @@ fn add_route(args: &[&[u8]]) -> i32 {
     };
 
     // Build rtentry structure for ioctl
-    let mut rt: libc::rtentry = unsafe { core::mem::zeroed() };
+    let mut rt: rtentry = unsafe { core::mem::zeroed() };
 
     // Set destination
     let dest_sin = unsafe { &mut *(&mut rt.rt_dst as *mut _ as *mut libc::sockaddr_in) };
@@ -377,7 +379,7 @@ fn add_route(args: &[&[u8]]) -> i32 {
         let gw_sin = unsafe { &mut *(&mut rt.rt_gateway as *mut _ as *mut libc::sockaddr_in) };
         gw_sin.sin_family = libc::AF_INET as u16;
         gw_sin.sin_addr.s_addr = parse_ipv4(gw).unwrap_or(0);
-        rt.rt_flags |= libc::RTF_GATEWAY as u16;
+        rt.rt_flags |= RTF_GATEWAY as u16;
     }
 
     // Set netmask
@@ -394,9 +396,9 @@ fn add_route(args: &[&[u8]]) -> i32 {
     };
 
     // Set flags
-    rt.rt_flags |= libc::RTF_UP as u16;
+    rt.rt_flags |= RTF_UP as u16;
     if is_host {
-        rt.rt_flags |= libc::RTF_HOST as u16;
+        rt.rt_flags |= RTF_HOST as u16;
     }
 
     // Set device if provided
@@ -465,7 +467,7 @@ fn del_route(args: &[&[u8]]) -> i32 {
     };
 
     // Build rtentry structure
-    let mut rt: libc::rtentry = unsafe { core::mem::zeroed() };
+    let mut rt: rtentry = unsafe { core::mem::zeroed() };
 
     // Set destination
     let dest_sin = unsafe { &mut *(&mut rt.rt_dst as *mut _ as *mut libc::sockaddr_in) };
@@ -489,9 +491,9 @@ fn del_route(args: &[&[u8]]) -> i32 {
         0xFFFFFF00
     };
 
-    rt.rt_flags = libc::RTF_UP as u16;
+    rt.rt_flags = RTF_UP as u16;
     if is_host {
-        rt.rt_flags |= libc::RTF_HOST as u16;
+        rt.rt_flags |= RTF_HOST as u16;
     }
 
     // Open socket for ioctl

--- a/src/applets/network/slattach.rs
+++ b/src/applets/network/slattach.rs
@@ -7,21 +7,21 @@ use crate::sys;
 use super::get_arg;
 
 // Line discipline constants
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const N_SLIP: libc::c_int = 1;      // Serial Line IP
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const N_CSLIP: libc::c_int = 2;     // SLIP + VJ header compression
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const N_SLIP6: libc::c_int = 3;     // 6-bit SLIP
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const N_CSLIP6: libc::c_int = 4;    // 6-bit SLIP + VJ compression
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const N_PPP: libc::c_int = 3;       // PPP (same as SLIP6 on some systems)
 
 // TTY ioctl for setting line discipline
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TIOCSETD: crate::io::IoctlReq = 0x5423u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TIOCGETD: crate::io::IoctlReq = 0x5424u32 as crate::io::IoctlReq;
 
 /// slattach - attach a network interface to a serial line
@@ -43,7 +43,7 @@ const TIOCGETD: crate::io::IoctlReq = 0x5424u32 as crate::io::IoctlReq;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn slattach(argc: i32, argv: *const *const u8) -> i32 {
     let mut protocol = N_CSLIP;
     let mut speed: Option<u32> = None;
@@ -226,7 +226,7 @@ pub fn slattach(argc: i32, argv: *const *const u8) -> i32 {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn slattach(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"slattach: only available on Linux\n");
     1

--- a/src/applets/network/sntp.rs
+++ b/src/applets/network/sntp.rs
@@ -28,7 +28,7 @@ const NTP_EPOCH_OFFSET: u64 = 2208988800; // Seconds from 1900 to 1970
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn sntp(argc: i32, argv: *const *const u8) -> i32 {
     let mut set_time = false;
     let mut server: Option<&[u8]> = None;
@@ -237,13 +237,13 @@ pub fn sntp(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn sntp(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"sntp: only available on Linux\n");
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_padded(val: u64, width: usize, buf: &mut [u8; 16]) {
     let s = sys::format_u64(val, buf);
     for _ in 0..(width.saturating_sub(s.len())) {
@@ -252,7 +252,7 @@ fn print_padded(val: u64, width: usize, buf: &mut [u8; 16]) {
     io::write_all(1, s);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn resolve_host(host: &[u8]) -> Option<libc::sockaddr_in> {
     if let Some(ip) = parse_ipv4(host) {
         let mut addr: libc::sockaddr_in = unsafe { core::mem::zeroed() };
@@ -298,7 +298,7 @@ fn resolve_host(host: &[u8]) -> Option<libc::sockaddr_in> {
     addr
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn parse_ipv4(s: &[u8]) -> Option<u32> {
     let mut parts = [0u8; 4];
     let mut part_idx = 0;

--- a/src/applets/network/telnet.rs
+++ b/src/applets/network/telnet.rs
@@ -35,7 +35,7 @@ const TELOPT_NAWS: u8 = 31;  // Window Size
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn telnet(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         io::write_str(2, b"Usage: telnet HOST [PORT]\n");
@@ -271,19 +271,19 @@ pub fn telnet(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn telnet(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"telnet: only available on Linux\n");
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 struct TelnetState {
     echo: bool,
     sga: bool,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl TelnetState {
     fn new() -> Self {
         TelnetState {
@@ -293,7 +293,7 @@ impl TelnetState {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn handle_telnet_option(sock: i32, cmd: u8, opt: u8, state: &mut TelnetState) {
     let response = match cmd {
         DO => {
@@ -344,7 +344,7 @@ fn handle_telnet_option(sock: i32, cmd: u8, opt: u8, state: &mut TelnetState) {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn resolve_host(host: &[u8], port: u16) -> Option<libc::sockaddr_in> {
     // Try to parse as IP address first
     if let Some(ip) = parse_ipv4(host) {
@@ -396,7 +396,7 @@ fn resolve_host(host: &[u8], port: u16) -> Option<libc::sockaddr_in> {
     addr
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn parse_ipv4(s: &[u8]) -> Option<u32> {
     let mut parts = [0u8; 4];
     let mut part_idx = 0;
@@ -434,7 +434,7 @@ fn parse_ipv4(s: &[u8]) -> Option<u32> {
          (parts[3] as u32))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_addr(addr: &libc::sockaddr_in) {
     let ip = u32::from_be(addr.sin_addr.s_addr);
     let port = u16::from_be(addr.sin_port);

--- a/src/applets/network/tftp.rs
+++ b/src/applets/network/tftp.rs
@@ -35,7 +35,7 @@ const TFTP_BLOCK_SIZE: usize = 512;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn tftp(argc: i32, argv: *const *const u8) -> i32 {
     let mut get_mode = false;
     let mut put_mode = false;
@@ -135,14 +135,14 @@ pub fn tftp(argc: i32, argv: *const *const u8) -> i32 {
     result
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn tftp(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"tftp: only available on Linux\n");
     1
 }
 
 /// Download file from TFTP server
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn tftp_get(sock: i32, server: &libc::sockaddr_in, remote: &[u8], local: &[u8]) -> i32 {
     // Build RRQ packet
     let mut packet = [0u8; 516];
@@ -267,7 +267,7 @@ fn tftp_get(sock: i32, server: &libc::sockaddr_in, remote: &[u8], local: &[u8]) 
 }
 
 /// Upload file to TFTP server
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn tftp_put(sock: i32, server: &libc::sockaddr_in, remote: &[u8], local: &[u8]) -> i32 {
     let fd = io::open(local, libc::O_RDONLY, 0);
     if fd < 0 {
@@ -412,7 +412,7 @@ fn tftp_put(sock: i32, server: &libc::sockaddr_in, remote: &[u8], local: &[u8]) 
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn resolve_host(host: &[u8]) -> Option<libc::sockaddr_in> {
     if let Some(ip) = parse_ipv4(host) {
         let mut addr: libc::sockaddr_in = unsafe { core::mem::zeroed() };
@@ -458,7 +458,7 @@ fn resolve_host(host: &[u8]) -> Option<libc::sockaddr_in> {
     addr
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn parse_ipv4(s: &[u8]) -> Option<u32> {
     let mut parts = [0u8; 4];
     let mut part_idx = 0;

--- a/src/applets/network/traceroute.rs
+++ b/src/applets/network/traceroute.rs
@@ -28,7 +28,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn traceroute(argc: i32, argv: *const *const u8) -> i32 {
     let mut max_ttl: u8 = 30;
     let mut port: u16 = 33434;
@@ -304,14 +304,14 @@ pub fn traceroute(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn traceroute(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"traceroute: only available on Linux\n");
     1
 }
 
 /// Resolve hostname to IPv4 address
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn resolve_host(host: &[u8]) -> Option<u32> {
     // First try parsing as IP address
     if let Some(addr) = parse_ipv4(host) {
@@ -421,7 +421,7 @@ fn print_ip(addr: u32) {
 }
 
 /// Calculate ICMP checksum
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn icmp_checksum(data: &[u8]) -> u16 {
     let mut sum: u32 = 0;
     let mut i = 0;

--- a/src/applets/network/tunctl.rs
+++ b/src/applets/network/tunctl.rs
@@ -7,21 +7,21 @@ use crate::sys;
 use super::get_arg;
 
 // TUN/TAP ioctl constants
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TUNSETIFF: crate::io::IoctlReq = 0x400454cau32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TUNSETPERSIST: crate::io::IoctlReq = 0x400454cbu32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TUNSETOWNER: crate::io::IoctlReq = 0x400454ccu32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const TUNSETGROUP: crate::io::IoctlReq = 0x400454ceu32 as crate::io::IoctlReq;
 
 // TUN/TAP flags
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const IFF_TUN: libc::c_short = 0x0001;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const IFF_TAP: libc::c_short = 0x0002;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const IFF_NO_PI: libc::c_short = 0x1000;
 
 /// tunctl - create and manage persistent TUN/TAP interfaces
@@ -44,7 +44,7 @@ const IFF_NO_PI: libc::c_short = 0x1000;
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn tunctl(argc: i32, argv: *const *const u8) -> i32 {
     let mut name: Option<&[u8]> = None;
     let mut uid: Option<libc::uid_t> = None;
@@ -193,13 +193,13 @@ pub fn tunctl(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn tunctl(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"tunctl: only available on Linux\n");
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn write_ifname(name: &[libc::c_char; libc::IFNAMSIZ]) {
     for &c in name.iter() {
         if c == 0 {
@@ -209,7 +209,7 @@ fn write_ifname(name: &[libc::c_char; libc::IFNAMSIZ]) {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn print_usage() {
     io::write_str(1, b"Usage: tunctl [OPTIONS]\n");
     io::write_str(1, b"Create and manage TUN/TAP network interfaces.\n\n");

--- a/src/applets/network/vconfig.rs
+++ b/src/applets/network/vconfig.rs
@@ -7,33 +7,33 @@ use crate::sys;
 use super::get_arg;
 
 // VLAN ioctl commands
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCGIFVLAN: crate::io::IoctlReq = 0x8982u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SIOCSIFVLAN: crate::io::IoctlReq = 0x8983u32 as crate::io::IoctlReq;
 
 // VLAN command codes
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const ADD_VLAN_CMD: libc::c_int = 0;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const DEL_VLAN_CMD: libc::c_int = 1;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SET_VLAN_INGRESS_PRIORITY_CMD: libc::c_int = 2;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SET_VLAN_EGRESS_PRIORITY_CMD: libc::c_int = 3;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SET_VLAN_FLAG_CMD: libc::c_int = 4;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const SET_VLAN_NAME_TYPE_CMD: libc::c_int = 5;
 
 // VLAN name types
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const VLAN_NAME_TYPE_PLUS_VID: libc::c_int = 0; // vlan0005
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const VLAN_NAME_TYPE_RAW_PLUS_VID: libc::c_int = 1; // eth0.0005
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const VLAN_NAME_TYPE_PLUS_VID_NO_PAD: libc::c_int = 2; // vlan5
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const VLAN_NAME_TYPE_RAW_PLUS_VID_NO_PAD: libc::c_int = 3; // eth0.5
 
 /// vconfig - VLAN configuration utility
@@ -62,7 +62,7 @@ const VLAN_NAME_TYPE_RAW_PLUS_VID_NO_PAD: libc::c_int = 3; // eth0.5
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn vconfig(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         print_usage();
@@ -190,14 +190,14 @@ pub fn vconfig(argc: i32, argv: *const *const u8) -> i32 {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn vconfig(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"vconfig: only available on Linux\n");
     1
 }
 
 // VLAN ioctl arguments structure
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct VlanIoctlArgs {
     cmd: libc::c_int,
@@ -206,7 +206,7 @@ struct VlanIoctlArgs {
     vlan_qos: libc::c_short,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 union VlanIoctlUnion {
     device2: [libc::c_char; 24],
@@ -217,7 +217,7 @@ union VlanIoctlUnion {
     flag: libc::c_uint,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn add_vlan(iface: &[u8], vid: u16) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -254,7 +254,7 @@ fn add_vlan(iface: &[u8], vid: u16) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn rem_vlan(vlan_iface: &[u8]) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -286,7 +286,7 @@ fn rem_vlan(vlan_iface: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_vlan_flag(vlan_iface: &[u8], flag: libc::c_int, value: libc::c_int) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -320,7 +320,7 @@ fn set_vlan_flag(vlan_iface: &[u8], flag: libc::c_int, value: libc::c_int) -> i3
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_egress_map(vlan_iface: &[u8], skb_prio: u32, vlan_qos: u16) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -354,7 +354,7 @@ fn set_egress_map(vlan_iface: &[u8], skb_prio: u32, vlan_qos: u16) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_ingress_map(vlan_iface: &[u8], skb_prio: u32, vlan_qos: u16) -> i32 {
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
     if sock < 0 {
@@ -388,7 +388,7 @@ fn set_ingress_map(vlan_iface: &[u8], skb_prio: u32, vlan_qos: u16) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_name_type(name_type: &[u8]) -> i32 {
     let type_val = if name_type == b"VLAN_PLUS_VID" {
         VLAN_NAME_TYPE_PLUS_VID

--- a/src/applets/process/chrt.rs
+++ b/src/applets/process/chrt.rs
@@ -47,7 +47,7 @@ pub fn chrt(argc: i32, argv: *const *const u8) -> i32 {
             } else if arg == b"-r" {
                 policy = libc::SCHED_RR;
             } else if arg == b"-o" {
-                policy = libc::SCHED_OTHER;
+                policy = sys::SCHED_OTHER;
             } else if arg[0] != b'-' {
                 break;
             }
@@ -84,7 +84,7 @@ pub fn chrt(argc: i32, argv: *const *const u8) -> i32 {
         }
 
         let policy_name = match current_policy {
-            libc::SCHED_OTHER => b"SCHED_OTHER" as &[u8],
+            sys::SCHED_OTHER => b"SCHED_OTHER" as &[u8],
             libc::SCHED_FIFO => b"SCHED_FIFO",
             libc::SCHED_RR => b"SCHED_RR",
             libc::SCHED_BATCH => b"SCHED_BATCH",

--- a/src/applets/process/uclampset.rs
+++ b/src/applets/process/uclampset.rs
@@ -86,7 +86,7 @@ impl Default for SchedAttr {
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn uclampset(argc: i32, argv: *const *const u8) -> i32 {
     let mut min: Option<u32> = None;
     let mut max: Option<u32> = None;
@@ -201,7 +201,7 @@ pub fn uclampset(argc: i32, argv: *const *const u8) -> i32 {
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn set_uclamp(pid: i32, min: Option<u32>, max: Option<u32>, reset: bool, reset_on_fork: bool) -> i32 {
     let mut attr = SchedAttr::default();
 
@@ -241,7 +241,7 @@ fn set_uclamp(pid: i32, min: Option<u32>, max: Option<u32>, reset: bool, reset_o
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show_uclamp(pid: i32) -> i32 {
     let mut attr = SchedAttr::default();
 
@@ -267,12 +267,12 @@ fn show_uclamp(pid: i32) -> i32 {
 }
 
 // Syscall wrappers
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 unsafe fn sched_getattr(pid: i32, attr: *mut SchedAttr, size: u32, flags: u32) -> i32 { unsafe {
     libc::syscall(libc::SYS_sched_getattr, pid, attr, size, flags) as i32
 }}
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 unsafe fn sched_setattr(pid: i32, attr: *const SchedAttr, flags: u32) -> i32 { unsafe {
     libc::syscall(libc::SYS_sched_setattr, pid, attr, flags) as i32
 }}
@@ -290,7 +290,7 @@ fn print_usage() {
     io::write_str(1, b"  -s       Show current settings\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn uclampset(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"uclampset: only available on Linux\n");
     1

--- a/src/applets/system/halt.rs
+++ b/src/applets/system/halt.rs
@@ -20,7 +20,7 @@ pub fn halt(argc: i32, argv: *const *const u8) -> i32 {
     let _ = argv;
     unsafe {
         libc::sync();
-        libc::reboot(libc::RB_HALT_SYSTEM);
+        crate::sys::reboot(crate::sys::RB_HALT_SYSTEM);
     }
     0
 }

--- a/src/applets/system/hostid.rs
+++ b/src/applets/system/hostid.rs
@@ -19,7 +19,7 @@ use crate::io;
 pub fn hostid(argc: i32, argv: *const *const u8) -> i32 {
     let _ = argc;
     let _ = argv;
-    io::write_num(1, unsafe { libc::gethostid() } as u64);
+    io::write_num(1, crate::sys::gethostid() as u64);
     io::write_str(1, b"\n");
     0
 }

--- a/src/applets/system/hwclock.rs
+++ b/src/applets/system/hwclock.rs
@@ -46,7 +46,7 @@ struct RtcTime {
 /// # Exit Status
 /// - 0: Success
 /// - >0: An error occurred
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn hwclock(argc: i32, argv: *const *const u8) -> i32 {
     let mut mode = Mode::Show;
     let mut utc = true;
@@ -103,14 +103,14 @@ pub fn hwclock(argc: i32, argv: *const *const u8) -> i32 {
     result
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 enum Mode {
     Show,
     SysToHc,
     HcToSys,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show_rtc_time(fd: i32, utc: bool) -> i32 {
     let mut rtc_tm = RtcTime::default();
 
@@ -153,7 +153,7 @@ fn show_rtc_time(fd: i32, utc: bool) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn sys_to_hc(fd: i32, utc: bool) -> i32 {
     // Get current system time
     let mut tv: libc::timeval = unsafe { core::mem::zeroed() };
@@ -207,7 +207,7 @@ fn sys_to_hc(fd: i32, utc: bool) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn hc_to_sys(fd: i32, utc: bool) -> i32 {
     let mut rtc_tm = RtcTime::default();
 
@@ -264,7 +264,7 @@ fn print_usage() {
     io::write_str(1, b"  -f, --rtc DEV   Use specified RTC device\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn hwclock(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"hwclock: only available on Linux\n");
     1

--- a/src/applets/system/i2ctransfer.rs
+++ b/src/applets/system/i2ctransfer.rs
@@ -61,7 +61,7 @@ struct I2cRdwrIoctlData {
 /// # Exit Status
 /// - 0: Success
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn i2ctransfer(argc: i32, argv: *const *const u8) -> i32 {
     let mut bus: Option<i32> = None;
     let mut verbose = false;
@@ -336,7 +336,7 @@ fn print_usage() {
     io::write_str(1, b"  i2ctransfer -y 0 w1@0x68 0x0f r1\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn i2ctransfer(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"i2ctransfer: only available on Linux\n");
     1

--- a/src/applets/system/insmod.rs
+++ b/src/applets/system/insmod.rs
@@ -23,7 +23,7 @@ use crate::applets::get_arg;
 /// # Exit Status
 /// - 0: Success
 /// - >0: An error occurred
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn insmod(argc: i32, argv: *const *const u8) -> i32 {
     if argc < 2 {
         io::write_str(2, b"Usage: insmod MODULE [params...]\n");
@@ -126,7 +126,7 @@ pub fn insmod(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn insmod(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"insmod: only available on Linux\n");
     1

--- a/src/applets/system/linux32.rs
+++ b/src/applets/system/linux32.rs
@@ -24,7 +24,7 @@ const PER_LINUX32: u64 = 0x0008;
 /// - Exit status of PROGRAM, or 1 on error
 pub fn linux32(argc: i32, argv: *const *const u8) -> i32 {
     // Set personality to 32-bit
-    let result = unsafe { libc::personality(PER_LINUX32 as libc::c_ulong) };
+    let result = unsafe { libc::personality(PER_LINUX32 as _) };
     if result < 0 {
         sys::perror(b"personality");
         return 1;

--- a/src/applets/system/login.rs
+++ b/src/applets/system/login.rs
@@ -28,7 +28,7 @@ use super::get_arg;
 /// # Exit Status
 /// - 0: Success (never returns on successful login)
 /// - 1: Error
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn login(argc: i32, argv: *const *const u8) -> i32 {
     let mut username: Option<&[u8]> = None;
     let mut skip_auth = false;
@@ -1003,7 +1003,7 @@ fn print_usage() {
     io::write_str(1, b"  -p        Preserve environment\n");
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn login(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"login: only available on Linux\n");
     1

--- a/src/applets/system/losetup.rs
+++ b/src/applets/system/losetup.rs
@@ -8,27 +8,27 @@ use crate::sys;
 use super::get_arg;
 
 // Loop device ioctl commands
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LOOP_SET_FD: crate::io::IoctlReq = 0x4C00u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LOOP_CLR_FD: crate::io::IoctlReq = 0x4C01u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LOOP_SET_STATUS64: crate::io::IoctlReq = 0x4C04u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LOOP_GET_STATUS64: crate::io::IoctlReq = 0x4C05u32 as crate::io::IoctlReq;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LOOP_CTL_GET_FREE: crate::io::IoctlReq = 0x4C82u32 as crate::io::IoctlReq;
 
 // Loop flags
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LO_FLAGS_READ_ONLY: u32 = 1;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LO_FLAGS_AUTOCLEAR: u32 = 4;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const LO_FLAGS_PARTSCAN: u32 = 8;
 
 /// Loop device info structure
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct LoopInfo64 {
     lo_device: u64,
@@ -67,7 +67,7 @@ struct LoopInfo64 {
 /// # Exit Status
 /// - 0: Success
 /// - >0: An error occurred
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn losetup(argc: i32, argv: *const *const u8) -> i32 {
     let mut show_all = false;
     let mut detach: Option<&[u8]> = None;
@@ -151,13 +151,13 @@ pub fn losetup(argc: i32, argv: *const *const u8) -> i32 {
     1
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn losetup(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"losetup: only available on Linux\n");
     1
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show_loops() -> i32 {
     // Iterate through /dev/loop* and show configured ones
     for n in 0..256 {
@@ -209,7 +209,7 @@ fn show_loops() -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn show_loop_info(device: &[u8]) -> i32 {
     let mut path = Vec::new();
     path.extend_from_slice(device);
@@ -248,7 +248,7 @@ fn show_loop_info(device: &[u8]) -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn find_free_loop() -> i32 {
     let fd = io::open(b"/dev/loop-control", libc::O_RDWR, 0);
     if fd < 0 {
@@ -272,7 +272,7 @@ fn find_free_loop() -> i32 {
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn setup_loop(device: Option<&[u8]>, file: &[u8], offset: u64, read_only: bool, partscan: bool) -> i32 {
     // Get device path
     let dev_path = if let Some(d) = device {
@@ -375,7 +375,7 @@ fn setup_loop(device: Option<&[u8]>, file: &[u8], offset: u64, read_only: bool, 
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn detach_loop(device: &[u8]) -> i32 {
     let mut path = Vec::new();
     path.extend_from_slice(device);

--- a/src/applets/system/poweroff.rs
+++ b/src/applets/system/poweroff.rs
@@ -20,7 +20,7 @@ pub fn poweroff(argc: i32, argv: *const *const u8) -> i32 {
     let _ = argv;
     unsafe {
         libc::sync();
-        libc::reboot(libc::RB_POWER_OFF);
+        crate::sys::reboot(crate::sys::RB_POWER_OFF);
     }
     0
 }

--- a/src/applets/system/reboot.rs
+++ b/src/applets/system/reboot.rs
@@ -20,7 +20,7 @@ pub fn reboot(argc: i32, argv: *const *const u8) -> i32 {
     let _ = argv;
     unsafe {
         libc::sync();
-        libc::reboot(libc::RB_AUTOBOOT);
+        crate::sys::reboot(crate::sys::RB_AUTOBOOT);
     }
     0
 }

--- a/src/applets/system/users.rs
+++ b/src/applets/system/users.rs
@@ -8,7 +8,7 @@ use crate::io;
 const USER_PROCESS: i16 = 7;
 
 // utmp structure for Linux (glibc compatible)
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct Utmp {
     ut_type: i16,
@@ -24,21 +24,21 @@ struct Utmp {
     __unused: [u8; 20],
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct ExitStatus {
     e_termination: i16,
     e_exit: i16,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct Timeval {
     tv_sec: i32,
     tv_usec: i32,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const UTMP_SIZE: usize = core::mem::size_of::<Utmp>();
 
 /// users - print logged in users
@@ -55,7 +55,7 @@ const UTMP_SIZE: usize = core::mem::size_of::<Utmp>();
 /// # Exit Status
 /// - 0: Success
 /// - >0: An error occurred
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn users(argc: i32, argv: *const *const u8) -> i32 {
     // Determine utmp file to use
     let utmp_path = if argc > 1 {
@@ -124,7 +124,7 @@ pub fn users(argc: i32, argv: *const *const u8) -> i32 {
     0
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn users(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"users: only available on Linux\n");
     1

--- a/src/applets/system/who.rs
+++ b/src/applets/system/who.rs
@@ -19,7 +19,7 @@ const USER_PROCESS: i16 = 7;
 const DEAD_PROCESS: i16 = 8;
 
 // utmp structure for Linux (glibc compatible)
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct Utmp {
     ut_type: i16,
@@ -35,21 +35,21 @@ struct Utmp {
     __unused: [u8; 20],
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct ExitStatus {
     e_termination: i16,
     e_exit: i16,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[repr(C)]
 struct Timeval {
     tv_sec: i32,
     tv_usec: i32,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const UTMP_SIZE: usize = core::mem::size_of::<Utmp>();
 
 /// who - show who is logged in
@@ -80,7 +80,7 @@ const UTMP_SIZE: usize = core::mem::size_of::<Utmp>();
 /// # Exit Status
 /// - 0: Success
 /// - >0: An error occurred
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn who(argc: i32, argv: *const *const u8) -> i32 {
     let mut show_header = false;
     let mut show_boot = false;
@@ -167,7 +167,7 @@ pub fn who(argc: i32, argv: *const *const u8) -> i32 {
                  quick_mode, my_tty)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn process_utmp(fd: i32, show_header: bool, show_boot: bool, show_dead: bool,
                 show_login: bool, show_runlevel: bool, show_time_change: bool,
                 show_idle: bool, show_mesg: bool, quick_mode: bool,
@@ -308,7 +308,7 @@ fn process_utmp(fd: i32, show_header: bool, show_boot: bool, show_dead: bool,
     0
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_my_tty() -> Option<[u8; 32]> {
     let mut tty_buf = [0u8; 256];
 
@@ -341,7 +341,7 @@ fn get_my_tty() -> Option<[u8; 32]> {
     Some(result)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_mesg_status(line: &[u8]) -> u8 {
     let mut path = [0u8; 64];
     path[..5].copy_from_slice(b"/dev/");
@@ -362,7 +362,7 @@ fn get_mesg_status(line: &[u8]) -> u8 {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_idle_time(line: &[u8]) -> i64 {
     let mut path = [0u8; 64];
     path[..5].copy_from_slice(b"/dev/");
@@ -382,7 +382,7 @@ fn get_idle_time(line: &[u8]) -> i64 {
     now.tv_sec as i64 - stat.st_atime as i64
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn format_time(timestamp: i64) {
     // Convert timestamp to broken-down time
     let tm = unsafe {
@@ -426,7 +426,7 @@ fn format_time(timestamp: i64) {
     io::write_all(1, &buf[..16]);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn format_idle(seconds: i64) {
     if seconds < 0 {
         io::write_str(1, b"  ?  ");
@@ -465,7 +465,7 @@ fn format_idle(seconds: i64) {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn who(_argc: i32, _argv: *const *const u8) -> i32 {
     io::write_str(2, b"who: only available on Linux\n");
     1

--- a/src/io.rs
+++ b/src/io.rs
@@ -35,13 +35,13 @@ use core::ptr;
 
 /// Portable ioctl request type.
 ///
-/// musl libc defines `ioctl(fd, request: c_int, ...)` while glibc uses
-/// `ioctl(fd, request: c_ulong, ...)`. This type alias allows ioctl
-/// request constants to compile correctly on both targets.
-#[cfg(target_env = "musl")]
+/// musl libc and Bionic define `ioctl(fd, request: c_int, ...)` while glibc
+/// uses `ioctl(fd, request: c_ulong, ...)`. This type alias allows ioctl
+/// request constants to compile correctly on all targets.
+#[cfg(any(target_env = "musl", target_os = "android"))]
 pub type IoctlReq = libc::c_int;
-/// Portable ioctl request type (c_ulong on glibc, c_int on musl).
-#[cfg(not(target_env = "musl"))]
+/// Portable ioctl request type (c_ulong on glibc, c_int on musl/Bionic).
+#[cfg(not(any(target_env = "musl", target_os = "android")))]
 pub type IoctlReq = libc::c_ulong;
 
 /// Maximum path length supported (matches PATH_MAX on Linux)

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -263,6 +263,104 @@ pub fn clear_errno() {
     unsafe { *libc::__error() = 0; }
 }
 
+/// Constants Bionic has but the libc crate does not bind for Android
+/// (`SCHED_OTHER` in sched.h, `_PC_FILESIZEBITS` in unistd.h). Applets
+/// reference these via `sys::` so a single code path works everywhere.
+#[cfg(not(target_os = "android"))]
+pub use libc::{SCHED_OTHER, _PC_FILESIZEBITS};
+#[cfg(target_os = "android")]
+pub const SCHED_OTHER: libc::c_int = 0;
+#[cfg(target_os = "android")]
+pub const _PC_FILESIZEBITS: libc::c_int = 0;
+
+/// reboot(2) commands; kernel ABI from linux/reboot.h, unbound in the libc
+/// crate for Android.
+#[cfg(not(target_os = "android"))]
+pub use libc::{RB_AUTOBOOT, RB_HALT_SYSTEM, RB_POWER_OFF};
+#[cfg(target_os = "android")]
+pub const RB_AUTOBOOT: libc::c_int = 0x01234567u32 as i32;
+#[cfg(target_os = "android")]
+pub const RB_HALT_SYSTEM: libc::c_int = 0xcdef0123u32 as i32;
+#[cfg(target_os = "android")]
+pub const RB_POWER_OFF: libc::c_int = 0x4321fedcu32 as i32;
+
+/// reboot(2). Bionic has the syscall but the libc crate binds no wrapper for
+/// Android, so issue it directly there.
+pub fn reboot(cmd: libc::c_int) -> i32 {
+    #[cfg(not(target_os = "android"))]
+    unsafe {
+        libc::reboot(cmd)
+    }
+    #[cfg(target_os = "android")]
+    unsafe {
+        const LINUX_REBOOT_MAGIC1: libc::c_uint = 0xfee1dead;
+        const LINUX_REBOOT_MAGIC2: libc::c_uint = 672274793;
+        libc::syscall(libc::SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, cmd, 0) as i32
+    }
+}
+
+/// gethostid(3). Bionic has no gethostid at all; there, mirror glibc's
+/// storage semantics: the 4 bytes in /etc/hostid if present, else 0.
+pub fn gethostid() -> i64 {
+    #[cfg(not(target_os = "android"))]
+    unsafe {
+        libc::gethostid() as i64
+    }
+    #[cfg(target_os = "android")]
+    {
+        let fd = io::open(b"/etc/hostid", libc::O_RDONLY, 0);
+        if fd < 0 {
+            return 0;
+        }
+        let mut buf = [0u8; 4];
+        let n = io::read(fd, &mut buf);
+        io::close(fd);
+        if n == 4 {
+            u32::from_ne_bytes(buf) as i64
+        } else {
+            0
+        }
+    }
+}
+
+/// Routing-table ABI from linux/route.h, which Bionic's net/route.h includes
+/// verbatim; the libc crate does not bind these for Android. The struct layout
+/// matches libc's rtentry field-for-field (on LP64 the rt_tos/rt_class/rt_pad4
+/// group occupies exactly the kernel's `void *rt_pad4` slot), so route and
+/// ifup share one construction path on every platform.
+#[cfg(not(target_os = "android"))]
+pub use libc::{rtentry, RTF_GATEWAY, RTF_HOST, RTF_UP};
+#[cfg(target_os = "android")]
+pub const RTF_UP: libc::c_ushort = 0x0001;
+#[cfg(target_os = "android")]
+pub const RTF_GATEWAY: libc::c_ushort = 0x0002;
+#[cfg(target_os = "android")]
+pub const RTF_HOST: libc::c_ushort = 0x0004;
+
+#[cfg(target_os = "android")]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct rtentry {
+    pub rt_pad1: libc::c_ulong,
+    pub rt_dst: libc::sockaddr,
+    pub rt_gateway: libc::sockaddr,
+    pub rt_genmask: libc::sockaddr,
+    pub rt_flags: libc::c_ushort,
+    pub rt_pad2: libc::c_short,
+    pub rt_pad3: libc::c_ulong,
+    pub rt_tos: libc::c_uchar,
+    pub rt_class: libc::c_uchar,
+    #[cfg(target_pointer_width = "64")]
+    pub rt_pad4: [libc::c_short; 3usize],
+    #[cfg(not(target_pointer_width = "64"))]
+    pub rt_pad4: [libc::c_short; 1usize],
+    pub rt_metric: libc::c_short,
+    pub rt_dev: *mut libc::c_char,
+    pub rt_mtu: libc::c_ulong,
+    pub rt_window: libc::c_ulong,
+    pub rt_irtt: libc::c_ushort,
+}
+
 /// Parse size with optional suffix (K, M, G, T, P, E)
 pub fn parse_size(s: &[u8]) -> Option<u64> {
     if s.is_empty() {


### PR DESCRIPTION
## Summary

Follow-up to #5: makes the **full armybox binary** build and run on Android/Bionic with no applet gated out, and adds `aarch64-linux-android` to the release matrix. Design spec: `docs/superpowers/specs/2026-08-18-android-bionic-support-design.md`.

- **ioctl requests**: the existing `io::IoctlReq` alias now covers Bionic (`c_int`, same as musl) — this alone resolved ~42 of the 59 Android build errors, since call sites already used the alias.
- **`sys.rs` compat layer**: `sys::reboot()` (direct `SYS_reboot` syscall on Android — the libc crate binds no wrapper), `sys::gethostid()` (Bionic has none; reads `/etc/hostid`, else 0, mirroring glibc storage semantics), `sys::rtentry`/`RTF_*` (kernel ABI from `linux/route.h`, which Bionic's `net/route.h` includes verbatim; layout verified byte-identical to libc's on LP64), plus re-export-or-define constants `SCHED_OTHER`, `_PC_FILESIZEBITS` (0, verified against Bionic `unistd.h`), and `RB_*`.
- **Applet parity**: 27 applets previously compiled as "only available on Linux" stubs on Android (`cfg(target_os = "linux")`) are now enabled via `cfg(any(target_os = "linux", target_os = "android"))` — zero additional shims turned out to be needed.
- **Release matrix**: `aarch64-linux-android` added through the existing cross-rs path (NDK-based image), building both `armybox` and `abpd-gen`.

## Verification

- `cargo check --release` at **0 errors** on `aarch64-linux-android` (was 59), `aarch64-unknown-linux-musl`, and `armv7-unknown-linux-musleabihf`
- Host release build clean; **1468 tests pass, 0 failed** (release profile)
- Constant/struct values cross-checked against Bionic sources (AOSP `unistd.h`, `net/route.h`) and the vendored libc 0.2.178 crate
- Code-reviewed; all confirmed findings addressed (applet parity gates, shim centralization, io-helper reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)