### PR TITLE
fix(build): resolve ARM release-target link failures

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,11 +6,6 @@
 # Remove for cross-compilation
 # rustflags = ["-C", "target-cpu=native"]
 
-[target.'cfg(all())']
-rustflags = [
-    # Link against libc for no_std
-    "-C", "link-arg=-lc",
-]
 
 # ============================================================================
 # x86_64 Linux (glibc)
@@ -21,6 +16,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,--hash-style=gnu",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -34,6 +31,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -46,6 +45,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--gc-sections",
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -59,6 +60,13 @@ rustflags = [
     "-C", "link-arg=-Wl,--gc-sections",
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
+    # musl pulls libgcc's f128 strtod intrinsics (aarch64) and __aeabi
+    # unwind routines (ARM32) from -lc; -lgcc must come after it.
+    "-C", "link-arg=-lgcc",
+    # ...and libgcc's unwind code needs abort() from libc in turn.
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -72,6 +80,13 @@ rustflags = [
     "-C", "link-arg=-Wl,--gc-sections",
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
+    # musl pulls libgcc's f128 strtod intrinsics (aarch64) and __aeabi
+    # unwind routines (ARM32) from -lc; -lgcc must come after it.
+    "-C", "link-arg=-lgcc",
+    # ...and libgcc's unwind code needs abort() from libc in turn.
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -84,6 +99,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -96,6 +113,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -108,6 +127,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================
@@ -120,6 +141,8 @@ rustflags = [
     "-C", "link-arg=-Wl,--as-needed",
     "-C", "link-arg=-Wl,-O2",
     "-C", "link-arg=-Wl,-s",
+    # Link against libc for no_std (ordered before target-specific libs)
+    "-C", "link-arg=-lc",
 ]
 
 # ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,14 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe { libc::_exit(1); }
 }
 
+/// The precompiled core/compiler_builtins rlibs carry unwind-table data that
+/// references this symbol even though the binary is panic=abort (seen on the
+/// aarch64 musl and Android release targets). It is never called; defining it
+/// only satisfies the linker.
+#[cfg(all(not(test), not(feature = "std")))]
+#[unsafe(no_mangle)]
+extern "C" fn rust_eh_personality() {}
+
 // ============================================================================
 // Global allocator using libc malloc (not used in test builds)
 // ============================================================================


### PR DESCRIPTION
Fixes the v0.5.0 release workflow's link failures on all three ARM targets (these targets had never successfully shipped — the v0.4.0 run failed too).

- No-op `rust_eh_personality` shim: the precompiled `compiler_builtins` rlib references it even under panic=abort.
- Per-target `-lc` ordering in `.cargo/config.toml`, with musl ARM targets linking `-lc -lgcc -lc` (musl's strtod needs libgcc's f128 intrinsics on aarch64 and `__aeabi` unwind routines on ARM32; libgcc's unwind code needs `abort()` back from libc).

Verified with the same cross images CI uses: armybox + abpd-gen link on all three ARM targets (musl static, Android PIE); x86_64 musl and host gnu unaffected; 1468 tests pass.

After merge: re-point the v0.5.0 tag at main to rerun the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)